### PR TITLE
fixed much of string formatting

### DIFF
--- a/YAPO/config/__init__.py
+++ b/YAPO/config/__init__.py
@@ -5,7 +5,7 @@ from YAPO.utils import Constants
 
 class Config(metaclass=Singleton):
   def __init__(self):
-    self.root_path = os.path.abspath(os.path.join(os.path.dirname(os.path.realpath(__file__)), '..', '..'))
+    self.root_path = os.path.abspath(os.path.dirname(os.path.dirname(os.path.dirname(os.path.realpath(__file__)))))
     self.yapo_path = os.path.join(self.root_path, Constants().code_subdir)
     self.site_path = os.path.join(self.root_path, Constants().site_subdir)
     self.data_path = os.path.join(self.root_path, Constants().data_subdir)

--- a/YAPO/urls.py
+++ b/YAPO/urls.py
@@ -133,7 +133,7 @@ try:
             # 2016-08-14 18:03:10.153443
             videos.const.LAST_ALL_SCENE_TAG = datetime.strptime(settings_content['last_all_scene_tag'],
                                                                 "%Y-%m-%d %H:%M:%S")
-            print("The last full scene tagging was done {}\n".format(videos.const.LAST_ALL_SCENE_TAG))
+            print(f"The last full scene tagging was done {videos.const.LAST_ALL_SCENE_TAG}\n")
 
 except FileNotFoundError:
     with open(YAPO.settings.CONFIG_JSON, 'w'):

--- a/YAPO/utils/__init__.py
+++ b/YAPO/utils/__init__.py
@@ -39,4 +39,4 @@ class Logger(metaclass=Singleton):
 
 
 def timeprint(message: str):
-  print('%s> %s' % (str(datetime.now().strftime(Config().timeprint_format)), message))
+  print(f"{datetime.now().strftime(Config().timeprint_format)}> {message}"

--- a/manage.py
+++ b/manage.py
@@ -45,7 +45,7 @@ if __name__ == "__main__":
         print("=================================================================")
         print("")
         # print("Static files dir is: {}".format(YAPO.settings.STATIC_ROOT))
-        print("Configdir is " + YAPO.settings.CONFIG_DIR)
+        print(f"Configdir is {YAPO.settings.CONFIG_DIR}")
         print(f"Media files are located in {YAPO.settings.MEDIA_ROOT},\nyou may want to consider backing them up.\n")
 
     from django.core.management import execute_from_command_line

--- a/videos/addScenes.py
+++ b/videos/addScenes.py
@@ -66,16 +66,12 @@ def get_files(walk_dir, make_video_sample):
 
 
 def create_sample_video(scene):
-    print("Trying to create a sample video for scene: {}".format(scene.name))
+    print(f"Trying to create a sample video for scene: {scene.name}")
     success = ffmpeg_process.ffmpeg_create_sammple_video(scene)
     if success:
-        print("Sample video for scene: {} created successfully.".format(scene.name))
+        print(f"Sample video for scene: {scene.name} created successfully.")
     else:
-        print(
-            "Something went wrong while trying to create video sample for scene: {}".format(
-                scene.name
-            )
-        )
+        print(f"Something went wrong while trying to create video sample for scene: {scene.name}")
 
 
 def create_scene(scene_path, make_sample_video):
@@ -96,9 +92,7 @@ def create_scene(scene_path, make_sample_video):
         if scene_in_db.thumbnail is None:
             print("Trying to use ffprobe on scene... ",end="")
             if ffmpeg_process.ffprobe_get_data_without_save(scene_in_db):
-                print(
-                    "OK, taking a screenshot... ", end=""
-                    )
+                print("OK, taking a screenshot... ", end="")
 
                 ffmpeg_process.ffmpeg_take_scene_screenshot_without_save(scene_in_db)
 
@@ -155,7 +149,7 @@ def create_scene(scene_path, make_sample_video):
                         os.path.abspath(sheet_path),
                     ]
                 )
-                print("Contact Sheet saved to " + os.path.abspath(sheet_path))
+                print("Contact Sheet saved to %s"%(os.path.abspath(sheet_path)))
             except:
                 print("Error creating contact sheet!")
         if make_sample_video:
@@ -165,7 +159,7 @@ def create_scene(scene_path, make_sample_video):
             if not os.path.isfile(video_filename_path):
                 create_sample_video(scene_in_db)
             else:
-                print("Sample for {} already exists!".format(scene_in_db.name))
+                print(f"Sample for {scene_in_db.name} already exists!")
 
             scene_in_db.save()
         
@@ -173,9 +167,7 @@ def create_scene(scene_path, make_sample_video):
         print("Trying to use ffprobe on scene... ", end="")
         if ffmpeg_process.ffprobe_get_data_without_save(current_scene):
             current_scene.save()
-            print(
-                "Taking a screenshot...", end=""
-            )
+            print("Taking a screenshot...", end="")
 
             ffmpeg_process.ffmpeg_take_scene_screenshot_without_save(current_scene)
 
@@ -234,7 +226,7 @@ def create_scene(scene_path, make_sample_video):
                             os.path.abspath(sheet_path),
                         ]
                     )
-                    print("Contact Sheet saved to " + os.path.abspath(sheet_path))
+                    print("Contact Sheet saved to %s"%(os.path.abspath(sheet_path)))
                 except:
                     print("Error creating contact sheet!")
 
@@ -268,9 +260,7 @@ def create_scene(scene_path, make_sample_video):
                 current_scene, actors, actors_alias, scene_tags, websites
             )
         else:
-            print(
-                "Failed to probe scene {}, skipping scene...".format(current_scene.name)
-            )
+            print(f"Failed to probe scene {current_scene.name}, skipping scene...")
 
 
 def add_scene_to_folder_view(scene_to_add):
@@ -310,7 +300,7 @@ def recursive_add_folders(parent, folders, scene_to_add, path_with_ids):
             path_with_ids = []
             if not Folder.objects.filter(name=folders[0]):
                 temp = Folder.objects.create(name=folders[0])
-                print("Created virtual folder: " + temp.name)
+                print(f"Created virtual folder: {temp.name}")
                 parent = Folder.objects.get(name=folders[0])
                 if parent.last_folder_name_only is None:
                     parent.last_folder_name_only = folders[0]
@@ -353,7 +343,7 @@ def recursive_add_folders(parent, folders, scene_to_add, path_with_ids):
 
             if not if_in_children:
                 parent = Folder.objects.create(name=folder_to_add, parent=parent)
-                print("Created virtual folder: " + parent.name)
+                print(f"Created virtual folder: {parent.name}")
                 if parent.last_folder_name_only is None:
                     parent.last_folder_name_only = folders[0]
                 parent.save()
@@ -377,10 +367,7 @@ def recursive_add_folders(parent, folders, scene_to_add, path_with_ids):
         if not parent.scenes.filter(name=scene_to_add.name):
             parent.scenes.add(scene_to_add)
             print(
-                "Added Scene: "
-                + scene_to_add.name
-                + " to virtual folder "
-                + parent.name
+                f"Added Scene: {scene_to_add.name} to virtual folder {parent.name}"
             )
             parent.save()
 
@@ -396,7 +383,7 @@ def clean_empty_folders():
 
 
 def recursive_function(parent, folder):
-    print("In folder " + folder.name)
+    print(f"In folder {folder.name}")
     if folder.get_next_sibling() is not None:
         sibling = folder.get_next_sibling()
         recursive_function(folder, sibling)
@@ -406,12 +393,12 @@ def recursive_function(parent, folder):
         for child in children:
             recursive_function(folder, child)
     else:
-        print("         " + folder.name + " is leaf")
+        print(f"         {folder.name} is leaf")
         if folder.scenes.all().count() == 0:
             name = folder.name
             parent.children.filter(pk=folder.id).delete()
             # folder.delete()
-            print(name + " didn't have any scenes and was deleted!")
+            print(f"{name} didn't have any scenes and was deleted!")
 
             # siblings = folder.get_siblings()
             # for sibling in siblings:
@@ -420,9 +407,7 @@ def recursive_function(parent, folder):
 
 def write_actors_to_file():
     actors = Actor.objects.all()
-    actors_string = ""
-    for actor in actors:
-        actors_string += "," + actor.name
+    actors_string = ",".join([actor.name for actor in actors])
 
     file = open("actors.txt", "w")
 
@@ -435,12 +420,12 @@ def populate_last_folder_name_in_virtual_folders():
     all_folders = Folder.objects.all()
     for folder in all_folders:
         if not folder.last_folder_name_only:
-            print("Folder name is" + folder.name)
+            print(f"Folder name is {folder.name}")
             name = os.path.normpath(folder.name)
             only_last = os.path.basename(name)
             if only_last == "":
                 only_last = name
-            print("Folder last name is {}".format(only_last))
+            print(f"Folder last name is {only_last}")
             folder.last_folder_name_only = only_last
             folder.save()
 

--- a/videos/aux_functions.py
+++ b/videos/aux_functions.py
@@ -11,7 +11,7 @@ def progress(count, total, suffix=''):
     percents = round(100.0 * count / float(total), 1)
     bar = '\u2588' * filled_len + '\u2591' * (bar_len - filled_len)
 
-    sys.stdout.write('%s [%s%s] ... %s\r' % (bar, percents, '%', suffix + "                 "))
+    sys.stdout.write(f"{bar} [{percents}%] ... {suffix}\r                 "))
 
 def progress_end():
     sys.stdout.flush() 
@@ -132,13 +132,13 @@ def strip_bad_chars(name):
         if char in name:
             # print("Before: " + name)
             name = name.replace(char, "")
-            print("Adding Data: " + name)
+            print(f"Adding Data: {name}")
     return name
 
 
 def save_actor_profile_image_from_web(image_link, actor, force):
     save_path = os.path.join(
-        videos.const.MEDIA_PATH, "actor/" + str(actor.id) + "/profile/"
+        videos.const.MEDIA_PATH, "actor", str(actor.id),"profile/"
     )
 
     if not os.path.exists(save_path):
@@ -189,9 +189,7 @@ def actor_folder_from_name_to_id():
         as_uri = urllib.request.pathname2url(rel_path)
 
         print(
-            "Actor {} thumb path is: {} \n and it should be {}".format(
-                actor.name, actor.thumbnail, as_uri
-            )
+           f"Actor {actor.name} thumb path is: {actor.thumbnail} \n and it should be {as_uri}"
         )
         print(actor.thumbnail != as_uri)
         if (actor.thumbnail != videos.const.UNKNOWN_PERSON_IMAGE_PATH) and (
@@ -204,7 +202,7 @@ def actor_folder_from_name_to_id():
                 )
 
                 print(
-                    "Renamed {} to {}".format(
+                    "Renamed %s to %s"%(
                         os.path.join(videos.const.MEDIA_PATH, "actor", actor.name),
                         os.path.join(videos.const.MEDIA_PATH, "actor", str(actor.id)),
                     )
@@ -234,14 +232,9 @@ def actor_folder_from_name_to_id():
                     as_uri_changed = urllib.request.pathname2url(rel_path_changed)
                     actor.thumbnail = as_uri_changed
                     actor.save()
-                    print(
-                        "Changed {} thumb in database to {}".format(
-                            actor.name, as_uri_changed
-                        )
-                    )
+                    print(f"Changed {actor.name} thumb in database to {as_uri_changed}")
                 else:
-                    print(
-                        "File {} not found!".format(
+                    print("File %s not found!"%(
                             os.path.join(videos.const.MEDIA_PATH, "actor", actor.name)
                         )
                     )
@@ -260,9 +253,7 @@ def actor_folder_from_name_to_id():
             actor.thumbnail = as_uri_changed
             actor.save()
 
-            print(
-                "Changed {} thumb in database to {}".format(actor.name, as_uri_changed)
-            )
+            print(f"Changed {actor.name} thumb in database to {as_uri_changed}")
 
     return True
 

--- a/videos/ffmpeg_process.py
+++ b/videos/ffmpeg_process.py
@@ -4,7 +4,7 @@ import sys
 import platform
 
 os.environ["DJANGO_SETTINGS_MODULE"] = "settings"
-sys.path.append(os.path.abspath("E:\djangoProject\YAPO\YAPO"))
+sys.path.append(os.path.abspath(os.path.join("E:","djangoProject","YAPO","YAPO"))
 
 import shutil
 import subprocess
@@ -83,13 +83,7 @@ def execute_subprocess(command_call, type_of_bin):
 
 
 def ffmpeg_take_screenshot(screenshot_time, filename):
-    command_call = '{} -y -ss {} -i "{}" {} {}'.format(
-        FFMPEG_BIN,
-        screenshot_time,
-        filename,
-        FFMPEG_SCREENSHOT_ARGUMENTS,
-        SCREENSHOT_OUTPUT_PATH,
-    )
+    command_call = f'{FFMPEG_BIN} -y -ss {screenshot_time} -i "{filename}" {FFMPEG_SCREENSHOT_ARGUMENTS} {SCREENSHOT_OUTPUT_PATH}'
 
 #    print("Taking screenshot of video...")  # (command_call)
 
@@ -97,7 +91,7 @@ def ffmpeg_take_screenshot(screenshot_time, filename):
 
 
 def ffprobe(filename):
-    command_call = '{} {} "{}"'.format(FFPROBE_BIN, FFPROBE_JSON_ARGUMENTS, filename)
+    command_call = f'{FFPROBE_BIN} {FFPROBE_JSON_ARGUMENTS} "{FILENAME}"'
     # print("Calling ffprobe...")# command call: {}".format(command_call))
 
     return execute_subprocess(command_call, "ffprobe")
@@ -107,7 +101,7 @@ def get_length(filename):
     # result = subprocess.Popen([FFPROBE_BIN, filename],
     #                           stdout=subprocess.PIPE, stderr=subprocess.STDOUT)
 
-    command_call = '{} "{}"'.format(FFPROBE_BIN, filename)
+    command_call = f'{FFPROBE_BIN} "{filename}"'
 #    print("Getting video length...")  # (command_call)
 
     result = subprocess.Popen(
@@ -128,8 +122,8 @@ def get_length(filename):
 
 # ffmpeg -i input.flv -vf fps=1 out%d.png
 def make_screenshots(fps_of_screenshots, filename):
-    input_argument = '-i "{}"'.format(filename)
-    video_filters = "-q:v 4 -vf fps={},scale=640:-2".format(fps_of_screenshots)
+    input_argument = f'-i "{filename}"'
+    video_filters = f"-q:v 4 -vf fps={fps_of_screenshots},scale=640:-2"
 
     print("Taking screenshots...")
     # print("{} {} {} {}".format(FFMPEG_BIN, input_argument, video_filters, FFMPEG_TEMP_OUTPUT_IMAGES))
@@ -139,13 +133,11 @@ def make_screenshots(fps_of_screenshots, filename):
 
 
 def make_video_from_screenshots(framerate):
-    framerate_argument = "-framerate {}".format(framerate)
-    input_argument = "-i {}".format(FFMPEG_TEMP_OUTPUT_IMAGES)
+    framerate_argument = f"-framerate {framerate}"
+    input_argument = f"-i {FFMPEG_TEMP_OUTPUT_IMAGES}"
     other_arguments = "-q:v 4 -c:v libx264 -pix_fmt yuv420p -preset ultrafast"
     output_video = OUTPUT_VIDEO_NAME
-    command_call = "{} {} {} {} {}".format(
-        FFMPEG_BIN, framerate_argument, input_argument, other_arguments, output_video
-    )
+    " ".join((FFMPEG_BIN, framerate_argument, input_argument, other_arguments, output_video))
     print(
         "Making video from frames..."
     )  # using ffmpeg command: \n{}".format(command_call))
@@ -158,7 +150,7 @@ def seconds_to_string(seconds):
     m, s = divmod(seconds, 60)
     h, m = divmod(m, 60)
 
-    return "{0:0>2}:{1:0>2}:{2:0>2}".format(int(h), int(m), int(s))
+    return f"{h:0>2}:{m:0>2}:{s:0>2}"
 
 
 def time_markers(
@@ -238,18 +230,16 @@ def make_sample_video(
 
 
 def extract_frames_in_given_time(filename, seek_time, frames_per_segment, start_number):
-    seek_argument = "-ss {}".format(seek_time)
-    input_argument = '-i "{}"'.format(filename)
-    number_of_frames_argument = "-vframes {}".format(frames_per_segment)
+    seek_argument = f"-ss {seek_time}"
+    input_argument = f'-i "{filename}"'
+    number_of_frames_argument = f"-vframes {frames_per_segment}"
     # scale_argument = "-q:v 1 -vf scale={}:trunc(ow/a/2)*2".format(image_width_pixels)
 
     # scales images to a fixed 16:9 size and adds black bars
-    scale_argument = '-q:v 4 -vf "scale={},pad=ih*16/9:ih:(ow-iw)/2:(oh-ih)/2"'.format(
-        SAMPLE_RESOLUTION
-    )
-    start_number_argument = "-start_number {}".format(start_number)
+    scale_argument = f'-q:v 4 -vf "scale={SAMPLE_RESOLUTION},pad=ih*16/9:ih:(ow-iw)/2:(oh-ih)/2"'
+    start_number_argument = f"-start_number {start_number}"
 
-    command_call = "{} {} {} {} {} {} {}".format(
+    command_call = " ".join((
         FFMPEG_BIN,
         seek_argument,
         input_argument,
@@ -257,7 +247,7 @@ def extract_frames_in_given_time(filename, seek_time, frames_per_segment, start_
         scale_argument,
         start_number_argument,
         FFMPEG_TEMP_OUTPUT_IMAGES,
-    )
+    ))
     print(
         "Extracting frames from scene..."
     )  # using ffmpeg command: \n{}".format(command_call))
@@ -277,7 +267,7 @@ def extract_frames_in_given_time(filename, seek_time, frames_per_segment, start_
     else:
         ans = -1
         print("Something went wrong while extracting video frames, exiting function...")
-        print("This is the output of the error: {}".format(a[0]))
+        print(f"This is the output of the error: {a[0]}")
 
     if b"Output file is empty, nothing was encoded" in output:
         ans = -1
@@ -352,11 +342,7 @@ def parse_ffprobe_data(ffprobe_json_output):
             try:
                 ans["framerate"] = framerate_numerator / framerate_denominator
             except ZeroDivisionError:
-                print(
-                    "Average framerate in JSON is "
-                    + temp
-                    + " could not divide by zero!"
-                )
+                print(f"Average framerate in JSON is {temp} could not divide by zero!")
                 ans["framerate"] = 0
 
     return ans
@@ -546,7 +532,7 @@ def main():
 
                 print(scene.name)
                 for key, y in parsed_ffprobe_data.items():
-                    print(key + ": " + str(y))
+                    print(f"{key}: {y}")
 
                 scene.framerate = parsed_ffprobe_data["framerate"]
                 scene.bit_rate = parsed_ffprobe_data["bitrate"]
@@ -560,7 +546,7 @@ def main():
 
                 scene.save()
         else:
-            print("Scene {} was already processed".format(scene.name.encode("utf-8")))
+            print(f"Scene {scene.name.encode('utf-8')} was already processed")
 
 
 if __name__ == "__main__":

--- a/videos/filename_parser.py
+++ b/videos/filename_parser.py
@@ -93,9 +93,7 @@ def parse_all_scenes(ignore_last_lookup):
       percent = (counter / scene_count) * 100
       os.system("cls" if os.name == "nt" else "clear")
       print(
-        "{}% done - scene {} out of {} - ignoring last lookup".format(
-          int(percent), counter, scene_count
-        )
+        f"{int(percent)}% done - scene {counter} out of {scene_count} - ignoring last lookup"
       )
 
       filtered_alias = filter_alias(actors_alias)
@@ -144,9 +142,7 @@ def parse_all_scenes(ignore_last_lookup):
         percent = (counter / scene_count) * 100
         os.system("cls" if os.name == "nt" else "clear")
         print(
-          "{}% done - scene {} out of {} - not ignoring last lookup".format(
-            int(percent), counter, scene_count
-          )
+          f"{int(percent)}% done - scene {counter} out of {scene_count} - not ignoring last lookup"
         )
 
         if (a[0]) or (b[0]) or (c[0]) or (d[0]):
@@ -158,7 +154,7 @@ def parse_all_scenes(ignore_last_lookup):
     else:
       for scene in scenes:
 
-        print("Scene {} out of {}".format(counter, scene_count))
+        print(f"Scene {counter} out of {scene_count}")
 
         if scene.last_filename_tag_lookup:
           actors_filtered = list(
@@ -227,7 +223,7 @@ def parse_all_scenes(ignore_last_lookup):
 
 
 def parse_scene_all_metadata(scene, actors, actors_alias, scene_tags, websites):
-  print("Parsing scene path:\r\n{}\r\n\r\n".format(scene.path_to_file))
+  print(f"Parsing scene path:\r\n{scene.path_to_file}\r\n\r\n")
 
   scene_path = scene.path_to_file.lower()
 
@@ -249,14 +245,14 @@ def parse_scene_all_metadata(scene, actors, actors_alias, scene_tags, websites):
   if site != "None":
     print(site)
   else:
-    print("")
+    print()
 
   if not (scene.hash):
     print("\r\nHashing scene... ", end="")
     scene.hash = get_hash(scene.path_to_file)  # NEW HASHER
-    print("ID: " + scene.hash)
+    print(f"ID: {scene.hash}")
   else:
-    print("Scene already hashed (" + scene.hash + ")")
+    print(f"Scene already hashed ({scene.hash})")
   scene.last_filename_tag_lookup = datetime.datetime.now()
 
   print("\r\nFinished parsing scene, touching last lookup")
@@ -402,7 +398,7 @@ def parse_actors_in_scene(scene_to_parse, scene_path, actors, actors_alias):
         add_actor_to_scene(actor, scene_to_parse)
 
         if actor.actor_tags.count() > 0:
-          print("Actor has " + str(actor.actor_tags.count()) + " tags...")
+          print(f"Actor has {actor.actor_tags.count()} tags...")
           t = 1
           for actor_tag in actor.actor_tags.all():
             current_tag = actor_tag.scene_tags.first()
@@ -426,7 +422,7 @@ def parse_actors_in_scene(scene_to_parse, scene_path, actors, actors_alias):
 
                   for excl in current_tag.exclusions.split(","):
                     excl = excl.strip().lower()
-                    print("There is an exclusion: " + excl + "...")
+                    print(f"There is an exclusion: {excl}...")
 
                     if len(excl) > 2:
                       regex_search_term = get_regex_search_term(
@@ -495,7 +491,7 @@ def parse_actors_in_scene(scene_to_parse, scene_path, actors, actors_alias):
         scene_path = ans["scene_path"]
 
         actor_in_alias = alias.actors.first()
-        print(alias.name + " is an alias for " + actor_in_alias.name)
+        print(f"{alias.name} is an alias for {actor_in_alias.name}")
         add_actor_to_scene(actor_in_alias, scene_to_parse)
 
         # if re.search(regex_search_term, scene_path, re.IGNORECASE) is not None:
@@ -516,17 +512,13 @@ def add_actor_to_scene(actor_to_add, scene_to_add_to):
   # if not Scene.objects.filter(pk=scene_to_add_to.pk, actors__pk=actor_to_add.pk):
   if not scene_to_add_to.actors.filter(pk=actor_to_add.pk):
     print(
-      "Adding Actor: {} to the scene {}".format(
-        actor_to_add.name, scene_to_add_to.name
-      )
+      f"Adding Actor: {actor_to_add.name} to the scene {scene_to_add_to.name}"
     )
     scene_to_add_to.actors.add(actor_to_add)
     scene_to_add_to.save()
   else:
     print(
-      "Actor: {} is already registered to the scene {}".format(
-        actor_to_add.name, scene_to_add_to.name
-      )
+      f"Actor: {actor_to_add.name} is already registered to the scene {scene_to_add_to.name}"
     )
 
 
@@ -537,16 +529,7 @@ def get_regex_search_term(name, delimiter):
       name = name.replace(char, "")
   name_split_list = name.split(delimiter)
   is_first_iteration = True
-  regex_search_term = ""
-  for part_of_name in name_split_list:
-
-    if is_first_iteration:
-      regex_search_term = regex_search_term + part_of_name
-      is_first_iteration = False
-    else:
-      regex_search_term = regex_search_term + ".{0,1}" + part_of_name
-      # print ("regex search term is: "  + regex_search_term)
-      # regex_search_term =  "r\"" + regex_search_term + "\""
+  regex_search_term = ".{0,1}".join(part_of_name for part_of_name in name_split_list)
   return regex_search_term
 
 
@@ -573,9 +556,7 @@ def parse_scene_tags_in_scene(scene, scene_path, scene_tags):
 
         if exclude == False:
           print(
-            "Adding Tag: {} to the scene {}".format(
-              scene_tag.name, scene.name
-            )
+            f"Adding Tag: {scene_tag.name} to the scene {scene.name}"
           )
           scene.scene_tags.add(scene_tag)
 
@@ -607,9 +588,7 @@ def parse_scene_tags_in_scene(scene, scene_path, scene_tags):
 
             if exclude == False:
               print(
-                "Adding Tag: {} to the scene {}".format(
-                  scene_tag.name, scene.name
-                )
+                f"Adding Tag: {scene_tag.name} to the scene {scene.name}"
               )
               scene.scene_tags.add(scene_tag)
   return scene_path
@@ -646,9 +625,7 @@ def parse_website_in_scenes(scene, scene_path, websites):
         for scene_tag in website.scene_tags.all():
           if not scene.scene_tags.filter(id=scene_tag.id):
             print(
-              "Adding Scene Tag '{}' to the scene {}".format(
-                website.name, scene.name
-              )
+              f"Adding Scene Tag '{website.name}' to the scene {scene.name}"
             )
             scene.scene_tags.add(scene_tag)
 
@@ -695,9 +672,7 @@ def parse_website_in_scenes(scene, scene_path, websites):
             for scene_tag in website.scene_tags.all():
               if not scene.scene_tags.filter(id=scene_tag.id):
                 print(
-                  "Adding Scene Tag '{}' to the scene {}".format(
-                    website.name, scene.name
-                  )
+                  f"Adding Scene Tag '{website.name}' to the scene {scene.name}"
                 )
             scene.scene_tags.add(scene_tag)
 

--- a/videos/misc_functions.py
+++ b/videos/misc_functions.py
@@ -17,26 +17,30 @@ import videos.const as const
 def strip_char(objects, char_to_strip):
     for o in objects:
         if char_to_strip in o.name:
-            print("Before: " + o.name)
+            print("Before: {o.name}")
             o.name = o.name.replace(char_to_strip, "")
-            print("After: " + o.name)
+            print("After: {o.name}")
             o.save()
 
 
 def fix_profile_images(actors):
     for actor in actors:
         path_to_check = os.path.join(
-            os.path.abspath("E:\\djangoProject\\YAPO\\videos\\static\\images\\actor"),
+            "E:","djangoProject",
+            "YAPO",
+            "videos",
+            "static",
+            "images",
+            "actor",
             actor.name,
-            "profile\\profile.jpg",
+            "profile",
+            "profile.jpg",
         )
         print(path_to_check)
         if os.path.isfile(path_to_check):
             rel_path = os.path.relpath(
-                path_to_check, "E:\\djangoProject\\YAPO\\videos\\"
+                path_to_check, os.path.join("E:","djangoProject","YAPO","videos")
             )
-            print(rel_path)
-            rel_path = rel_path.replace("\\", "/")
             print(rel_path)
             actor.thumbnail = rel_path
             actor.save()

--- a/videos/models.py
+++ b/videos/models.py
@@ -20,7 +20,7 @@ class ActorAlias(models.Model):
     # actor = models.ForeignKey(Actor, on_delete=models.CASCADE)
 
     def __str__(self):
-        return "%s " % (self.name,)
+        return f"{self.name} "
 
 
 class SceneTag(models.Model):
@@ -38,7 +38,7 @@ class SceneTag(models.Model):
     modified_date = models.DateTimeField(auto_now=True)
 
     def __str__(self):
-        return "%s " % (self.name,)
+        return f"{self.name} "
 
 
 class ActorTag(models.Model):
@@ -59,7 +59,7 @@ class ActorTag(models.Model):
     modified_date = models.DateTimeField(auto_now=True)
 
     def __str__(self):
-        return "%s " % (self.name,)
+        return f"{self.name} "
 
 
 class Actor(models.Model):
@@ -135,7 +135,7 @@ class Website(models.Model):
     modified_date = models.DateTimeField(auto_now=True)
 
     def __str__(self):
-        return "%s " % (self.name,)
+        return f"{self.name} "
 
 
 class Scene(models.Model):
@@ -171,7 +171,7 @@ class Scene(models.Model):
     modified_date = models.DateTimeField(auto_now=True)
 
     def __str__(self):
-        return "%s " % (self.name,)
+        return f"{self.name} "
 
     def get_absolute_url(self):
         return reverse("videos:scene-details", kwargs={"pk": self.pk})
@@ -189,7 +189,7 @@ class Folder(MPTTModel):
     modified_date = models.DateTimeField(auto_now=True)
 
     def __str__(self):
-        return "%s " % (self.name,)
+        return f"{self.name} "
 
     class MPTTMeta:
         order_insertion_by = ["name"]
@@ -209,7 +209,7 @@ class Playlist(models.Model):
     modified_date = models.DateTimeField(auto_now=True)
 
     def __str__(self):
-        return "%s " % (self.name,)
+        return f"{self.name} "
 
 
 @receiver(signals.post_save, sender=ActorTag)

--- a/videos/scrapers/filenames.py
+++ b/videos/scrapers/filenames.py
@@ -30,10 +30,7 @@ os.environ.setdefault("DJANGO_SETTINGS_MODULE", "YAPO.settings")
 # MEDIA_PATH = "videos\\media"
 
 def onlyChars(input):
-    valids = ""
-    for character in input:
-        if character.isalpha():
-            valids += character
+    valids = "".join(char for char in input if char.isalpha())
     return valids
     
 def parse(scene):
@@ -51,7 +48,7 @@ def matcher(text):
         return("Unknown")
 
 def site_facialfest(text):
-    if "facialfest" in text.lower() or "facial fest" in text.lower(): return("RENAME|Facial Fest")
+    if "facialfest" in text.lower().replace(" ",""): return("RENAME|Facial Fest")
     if len(text) < 6: return False
     if text[:2].lower() == "ff":
         site="FF"

--- a/videos/scrapers/freeones.py
+++ b/videos/scrapers/freeones.py
@@ -30,10 +30,7 @@ os.environ.setdefault("DJANGO_SETTINGS_MODULE", "YAPO.settings")
 # MEDIA_PATH = "videos\\media"
 
 def onlyChars(input):
-    valids = ""
-    for character in input:
-        if character.isalpha():
-            valids += character
+    valids = "".join(char for char in input if char.isalpha())
     return valids
 
 def inchtocm(input):
@@ -55,13 +52,13 @@ def search_freeones(actor_to_search, alias, force):
     if alias:
         name_with_plus = alias.name.replace(' ', '+')
         name_with_dash = alias.name.replace(' ', '-')        
-        print("searching AKA: " + alias.name+"... ",end="")
+        print(f"searching AKA: {alias.name}... ",end="")
         name = alias.name
     else:
         name_with_plus = name.replace(' ', '+')
         name_with_dash = name.replace(' ', '-')
-        print("Searching Freeones for: " + actor_to_search.name + "... ",end="")
-    r = requests.get("https://www.freeones.com/babes?q=" + name_with_dash, verify=False)
+        print(f"Searching Freeones for: {actor_to_search.name}... ",end="")
+    r = requests.get(f"https://www.freeones.com/babes?q={name_with_dash}", verify=False)
 
     soup = BeautifulSoup(r.content, "html5lib")
 
@@ -74,7 +71,7 @@ def search_freeones(actor_to_search, alias, force):
     
         success = True
         print("")
-        aux.progress(1,27,"Found " + actor_to_search.name + ", parsing...")
+        aux.progress(1,27,f"Found {actor_to_search.name}, parsing...")
         #print("\nI found " + actor_to_search.name + ", so I am looking for information on her profile page.")
         actor_to_search.gender = 'F'
         actor_to_search.save()
@@ -83,7 +80,7 @@ def search_freeones(actor_to_search, alias, force):
 
         soup = BeautifulSoup(r.content, "html5lib")
         soup_links = soup.find_all("a")
-        href_found = "/"+name_with_dash + "/profile" #match_text_in_link_to_query(soup_links, "Profile")
+        href_found = f"/{name_with_dash}/profile" #match_text_in_link_to_query(soup_links, "Profile")
         free_ones_bio_search = soup.find_all("div", {"class": "js-read-more-text read-more-text-ellipsis"})
         free_ones_career_status_search = soup.find_all("div", {"class": "timeline-horisontal"})
         free_ones_biography = free_ones_bio_search[0].get_text(strip=True)
@@ -104,7 +101,8 @@ def search_freeones(actor_to_search, alias, force):
             profile_thumb = soup.find("img", {'class': 'img-fluid'})
             profile_thumb_parent = profile_thumb.parent
             href=profile_thumb_parent['href']
-            if href[0]=="/": href = "https://www.freeones.com" + href
+            if href[0]=="/":
+                href = f"https://www.freeones.com{href}"
             has_image = False
             if len(href)>3:     
                 has_image = True
@@ -133,13 +131,13 @@ def search_freeones(actor_to_search, alias, force):
                     if picture_list.find("a"):
                         first_picture = picture_list.find("a")
                         #print("Saving... ", end="")
-                        save_path = os.path.join(videos.const.MEDIA_PATH, 'actor/' + str(actor_to_search.id) + '/profile/')
+                        save_path = os.path.join(videos.const.MEDIA_PATH, 'actor', str(actor_to_search.id), 'profile')
                         #print("Profile pic path: " + save_path)
                         save_file_name = os.path.join(save_path, 'profile.jpg')
                         if not os.path.isfile(save_file_name):
                             if first_picture['href']:
                                 if re.match(r'^\/\/', first_picture['href']):
-                                        first_picture_link = "https:" + first_picture['href']
+                                        first_picture_link = f"https:{first_picture['href']}"
                                         aux.save_actor_profile_image_from_web(first_picture_link, actor_to_search,force)
                                         aux.progress(4,27,"Storing photo")
                                 elif re.match(r'^.*jpg$', first_picture['href']):
@@ -206,7 +204,7 @@ def search_freeones(actor_to_search, alias, force):
                     try:
                         href = official_link['href']
                         if href not in actor_to_search.official_pages:
-                            actor_to_search.official_pages = actor_to_search.official_pages + official_link['href'] + ","  
+                            actor_to_search.official_pages += f"{official_link['href']},"  
                             #print ("Official Website added: " + official_link['href'])
                     except:
                         #print("Actor apparently has no official website")
@@ -576,7 +574,7 @@ def search_freeones(actor_to_search, alias, force):
         print("")
     try:
         if success:
-            aux.progress(29,29,str(num) + " tags parsed for " + actor_to_search.name + ".")
+            aux.progress(29,29,f"{num} tags parsed for {actor_to_search.name}.")
             aux.progress_end()
         print("")
     except:

--- a/videos/scrapers/googleimages.py
+++ b/videos/scrapers/googleimages.py
@@ -181,7 +181,7 @@ class googleimagesdownload:
         except Exception as e:
             print("Looks like we cannot locate the path the 'chromedriver' (use the '--chromedriver' "
                   "argument to specify the path to the executable.) or google chrome browser is not "
-                  "installed on your machine (exception: %s)" % e)
+                  f"installed on your machine (exception: {e})")
             sys.exit()
         browser.set_window_size(1024, 768)
 
@@ -236,7 +236,7 @@ class googleimagesdownload:
             start_line = s.find('class="dtviD"')
             start_content = s.find('href="', start_line + 1)
             end_content = s.find('">', start_content + 1)
-            url_item = "https://www.google.com" + str(s[start_content + 6:end_content])
+            url_item = f"https://www.google.com{s[start_content + 6:end_content]}"
             url_item = url_item.replace('&amp;', '&')
 
             start_line_2 = s.find('class="dtviD"')
@@ -309,10 +309,10 @@ class googleimagesdownload:
             image_name = image_name[:image_name.find('?')]
         # if ".jpg" in image_name or ".gif" in image_name or ".png" in image_name or ".bmp" in image_name or ".svg" in image_name or ".webp" in image_name or ".ico" in image_name:
         if any(map(lambda extension: extension in image_name, extensions)):
-            file_name = main_directory + "/" + image_name
+            file_name = f"{main_directory}/{image_name}"
         else:
-            file_name = main_directory + "/" + image_name + ".jpg"
-            image_name = image_name + ".jpg"
+            file_name = f"{main_directory}/{image_name}.jpg"
+            image_name = f"{image_name}.jpg"
 
         try:
             output_file = open(file_name, 'wb')
@@ -322,7 +322,7 @@ class googleimagesdownload:
             raise e
         except OSError as e:
             raise e
-        print("completed ====> " + image_name.encode('raw_unicode_escape').decode('utf-8'))
+        print(f"completed ====> {image_name.encode('raw_unicode_escape').decode('utf-8')}")
         return
 
     def similar_images(self,similar_images):
@@ -330,7 +330,7 @@ class googleimagesdownload:
         cur_version = sys.version_info
         if cur_version >= version:  # If the Current Version of Python is 3.0 or above
             try:
-                searchUrl = 'https://www.google.com/searchbyimage?site=search&sa=X&image_url=' + similar_images
+                searchUrl = f'https://www.google.com/searchbyimage?site=search&sa=X&image_url={similar_images}'
                 headers = {}
                 headers['User-Agent'] = "Mozilla/5.0 (Windows NT 6.1) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/41.0.2228.0 Safari/537.36"
 
@@ -341,7 +341,7 @@ class googleimagesdownload:
                 l2 = content.find('&', l1)
                 urll = content[l1:l2]
 
-                newurl = "https://www.google.com/search?tbs=sbi:" + urll + "&site=search&sa=X"
+                newurl = f"https://www.google.com/search?tbs=sbi:{urll}&site=search&sa=X"
                 req2 = urllib.request.Request(newurl, headers=headers)
                 resp2 = urllib.request.urlopen(req2)
                 l3 = content.find('/search?sa=X&amp;q=')
@@ -349,10 +349,10 @@ class googleimagesdownload:
                 urll2 = content[l3 + 19:l4]
                 return urll2
             except:
-                return "Cloud not connect to Google Images endpoint"
+                return "Could not connect to Google Images endpoint"
         else:  # If the Current Version of Python is 2.x
             try:
-                searchUrl = 'https://www.google.com/searchbyimage?site=search&sa=X&image_url=' + similar_images
+                searchUrl = f'https://www.google.com/searchbyimage?site=search&sa=X&image_url={similar_images}'
                 headers = {}
                 headers['User-Agent'] = "Mozilla/5.0 (X11; Linux i686) AppleWebKit/537.17 (KHTML, like Gecko) Chrome/24.0.1312.27 Safari/537.17"
 
@@ -363,7 +363,7 @@ class googleimagesdownload:
                 l2 = content.find('&', l1)
                 urll = content[l1:l2]
 
-                newurl = "https://www.google.com/search?tbs=sbi:" + urll + "&site=search&sa=X"
+                newurl = f"https://www.google.com/search?tbs=sbi:{urll}&site=search&sa=X"
                 req2 = urllib2.Request(newurl, headers=headers)
                 resp2 = urllib2.urlopen(req2)
                 l3 = content.find('/search?sa=X&amp;q=')
@@ -371,7 +371,7 @@ class googleimagesdownload:
                 urll2 = content[l3 + 19:l4]
                 return(urll2)
             except:
-                return "Cloud not connect to Google Images endpoint"
+                return "Could not connect to Google Images endpoint"
 
     #Building URL parameters
     def build_url_parameters(self,arguments):
@@ -385,13 +385,13 @@ class googleimagesdownload:
         if arguments['time_range']:
             json_acceptable_string = arguments['time_range'].replace("'", "\"")
             d = json.loads(json_acceptable_string)
-            time_range = ',cdr:1,cd_min:' + d['time_min'] + ',cd_max:' + d['time_max']
+            time_range = f",cdr:1,cd_min:{d['time_min']},cd_max:{d['time_max']}"
         else:
             time_range = ''
 
         if arguments['exact_size']:
             size_array = [x.strip() for x in arguments['exact_size'].split(',')]
-            exact_size = ",isz:ex,iszw:" + str(size_array[0]) + ",iszh:" + str(size_array[1])
+            exact_size = f",isz:ex,iszw:{size_array[0]},iszh:{size_array[1]}"
         else:
             exact_size = ''
 
@@ -430,13 +430,11 @@ class googleimagesdownload:
         elif similar_images:
             print(similar_images)
             keywordem = self.similar_images(similar_images)
-            url = 'https://www.google.com/search?q=' + keywordem + '&espv=2&biw=1366&bih=667&site=webhp&source=lnms&tbm=isch&sa=X&ei=XosDVaCXD8TasATItgE&ved=0CAcQ_AUoAg'
+            url = f"https://www.google.com/search?q={keywordem}&espv=2&biw=1366&bih=667&site=webhp&source=lnms&tbm=isch&sa=X&ei=XosDVaCXD8TasATItgE&ved=0CAcQ_AUoAg"
         elif specific_site:
-            url = 'https://www.google.com/search?q=' + quote(
-                search_term.encode('utf-8')) + '&as_sitesearch=' + specific_site + '&espv=2&biw=1366&bih=667&site=webhp&source=lnms&tbm=isch' + params + '&sa=X&ei=XosDVaCXD8TasATItgE&ved=0CAcQ_AUoAg'
+            url = f"https://www.google.com/search?q={quote(search_term.encode('utf-8'))}&as_sitesearch={specific_site}&espv=2&biw=1366&bih=667&site=webhp&source=lnms&tbm=isch{params}&sa=X&ei=XosDVaCXD8TasATItgE&ved=0CAcQ_AUoAg"
         else:
-            url = 'https://www.google.com/search?q=' + quote(
-                search_term.encode('utf-8')) + '&espv=2&biw=1366&bih=667&site=webhp&source=lnms&tbm=isch' + params + '&sa=X&ei=XosDVaCXD8TasATItgE&ved=0CAcQ_AUoAg'
+            url = f"https://www.google.com/search?q={quote(search_term.encode('utf-8'))}&espv=2&biw=1366&bih=667&site=webhp&source=lnms&tbm=isch{params}&sa=X&ei=XosDVaCXD8TasATItgE&ved=0CAcQ_AUoAg"
 
         #safe search check
         if safe_search:
@@ -452,7 +450,7 @@ class googleimagesdownload:
             size = file_info.st_size
             for x in ['bytes', 'KB', 'MB', 'GB', 'TB']:
                 if size < 1024.0:
-                    return "%3.1f %s" % (size, x)
+                    return f"{size:3.1f} {x}"
                 size /= 1024.0
             return size
 
@@ -480,7 +478,7 @@ class googleimagesdownload:
 
     # make directories
     def create_directories(self,main_directory, dir_name,thumbnail,thumbnail_only):
-        dir_name_thumbnail = dir_name + " - thumbnail"
+        dir_name_thumbnail = f"{dir_name} - thumbnail"
         # make a search keyword  directory
         try:
             if not os.path.exists(main_directory):
@@ -513,7 +511,7 @@ class googleimagesdownload:
     # Download Image thumbnails
     def download_image_thumbnail(self,image_url,main_directory,dir_name,return_image_name,print_urls,socket_timeout,print_size,no_download,save_source,img_src,ignore_urls):
         if print_urls or no_download:
-            print("Image URL: " + image_url)
+            print(f"Image URL: {image_url}")
         if no_download:
             return "success","Printed url without downloading"
         try:
@@ -530,50 +528,50 @@ class googleimagesdownload:
                 data = response.read()
                 response.close()
 
-                path = remove_illegal_characters(main_directory + "/" + dir_name + " - thumbnail" + "/" + return_image_name)
+                path = remove_illegal_characters(os.path.join(main_directory, f"{dir_name} - thumbnail", return_image_name)
 
                 try:
                     output_file = open(path, 'wb')
                     output_file.write(data)
                     output_file.close()
                     if save_source:
-                        list_path = main_directory + "/" + save_source + ".txt"
+                        list_path = os.path.join(main_directory, f"{save_source}.txt")
                         list_file = open(list_path,'a')
                         list_file.write(path + '\t' + img_src + '\n')
                         list_file.close()
                 except OSError as e:
                     download_status = 'fail'
-                    download_message = "OSError on an image...trying next one..." + " Error: " + str(e)
+                    download_message = f"OSError on an image...trying next one... Error: {e}"
                 except IOError as e:
                     download_status = 'fail'
-                    download_message = "IOError on an image...trying next one..." + " Error: " + str(e)
+                    download_message = f"IOError on an image...trying next one... Error: {e}"
 
                 download_status = 'success'
-                download_message = "Completed Image Thumbnail ====> " + return_image_name
+                download_message = f"Completed Image Thumbnail ====> {return_image_name}"
 
                 # image size parameter
                 if print_size:
-                    print("Image Size: " + str(self.file_size(path)))
+                    print(f"Image Size: {self.file_size(path)}")
 
             except UnicodeEncodeError as e:
                 download_status = 'fail'
-                download_message = "UnicodeEncodeError on an image...trying next one..." + " Error: " + str(e)
+                download_message = f"UnicodeEncodeError on an image...trying next one... Error: {e}"
 
         except HTTPError as e:  # If there is any HTTPError
             download_status = 'fail'
-            download_message = "HTTPError on an image...trying next one..." + " Error: " + str(e)
+            download_message = f"HTTPError on an image...trying next one... Error: {e}"
 
         except URLError as e:
             download_status = 'fail'
-            download_message = "URLError on an image...trying next one..." + " Error: " + str(e)
+            download_message = f"URLError on an image...trying next one... Error: {e}"
 
         except ssl.CertificateError as e:
             download_status = 'fail'
-            download_message = "CertificateError on an image...trying next one..." + " Error: " + str(e)
+            download_message = f"CertificateError on an image...trying next one... Error: {e}"
 
         except IOError as e:  # If there is any IOError
             download_status = 'fail'
-            download_message = "IOError on an image...trying next one..." + " Error: " + str(e)
+            download_message = f"IOError on an image...trying next one... Error: {e}"
         return download_status, download_message
 
 
@@ -581,7 +579,7 @@ class googleimagesdownload:
     def download_image(self,image_url,image_format,main_directory,dir_name,count,print_urls,socket_timeout,prefix,print_size,no_numbering,no_download,save_source,img_src,silent_mode,thumbnail_only,format,ignore_urls):
         if not silent_mode:
             if print_urls or no_download:
-                print("Image URL: " + image_url)
+                print(f"Image URL: {image_url}")
         if ignore_urls:
             if any(url in image_url for url in ignore_urls.split(',')):
                 return "fail", "Image ignored due to 'ignore url' parameter", None, image_url
@@ -620,93 +618,93 @@ class googleimagesdownload:
                     return_image_name = ''
                     absolute_path = ''
                     return download_status, download_message, return_image_name, absolute_path
-                elif image_name.lower().find("." + image_format) < 0:
-                    image_name = image_name + "." + image_format
+                elif image_name.lower().find(f".{image_format}") < 0:
+                    image_name += f".{image_format}"
                 else:
                     image_name = image_name[:image_name.lower().find("." + image_format) + (len(image_format) + 1)]
 
                 # prefix name in image
                 if not prefix:
-                    prefix = prefix + "_"
+                    prefix += "_"
                 else:
                     prefix = ''
 
                 if no_numbering:
-                    path = main_directory + "/" + dir_name + "/" + prefix + image_name
+                    path = os.path.join(main_directory, dir_name, f"{prefix}{image_name}")
                 else:
-                    path = main_directory + "/" + dir_name + "/" + prefix + str(count) + "." + image_name
+                    path = os.path.join(main_directory, dir_name, f"{prefix}{count}.{image_name}")
 
                 try:
                     output_file = open(path, 'wb')
                     output_file.write(data)
                     output_file.close()
                     if save_source:
-                        list_path = main_directory + "/" + save_source + ".txt"
+                        list_path = os.path.join(main_directory, f"{save_source}.txt")
                         list_file = open(list_path,'a')
-                        list_file.write(path + '\t' + img_src + '\n')
+                        list_file.write(f"{path}\t{img_src}\n")
                         list_file.close()
                     absolute_path = os.path.abspath(path)
                 except OSError as e:
                     download_status = 'fail'
-                    download_message = "OSError on an image...trying next one..." + " Error: " + str(e)
+                    download_message = f"OSError on an image...trying next one... Error: {e}"
                     return_image_name = ''
                     absolute_path = ''
 
                 #return image name back to calling method to use it for thumbnail downloads
                 download_status = 'success'
-                download_message = "Completed Image ====> " + prefix + str(count) + "." + image_name
-                return_image_name = prefix + str(count) + "." + image_name
+                download_message = f"Completed Image ====> {prefix}{count}.{image_name}"
+                return_image_name = f"{prefix}{count}.{image_name}"
 
                 # image size parameter
                 if not silent_mode:
                     if print_size:
-                        print("Image Size: " + str(self.file_size(path)))
+                        print(f"Image Size: {self.file_size(path)}")
 
             except UnicodeEncodeError as e:
                 download_status = 'fail'
-                download_message = "UnicodeEncodeError on an image...trying next one..." + " Error: " + str(e)
+                download_message = f"UnicodeEncodeError on an image...trying next one... Error: {e}"
                 return_image_name = ''
                 absolute_path = ''
 
             except URLError as e:
                 download_status = 'fail'
-                download_message = "URLError on an image...trying next one..." + " Error: " + str(e)
+                download_message = f"URLError on an image...trying next one... Error: {e}"
                 return_image_name = ''
                 absolute_path = ''
                 
             except BadStatusLine as e:
                 download_status = 'fail'
-                download_message = "BadStatusLine on an image...trying next one..." + " Error: " + str(e)
+                download_message = f"BadStatusLine on an image...trying next one... Error: {e}"
                 return_image_name = ''
                 absolute_path = ''
 
         except HTTPError as e:  # If there is any HTTPError
             download_status = 'fail'
-            download_message = "HTTPError on an image...trying next one..." + " Error: " + str(e)
+            download_message = f"HTTPError on an image...trying next one... Error: {e}"
             return_image_name = ''
             absolute_path = ''
 
         except URLError as e:
             download_status = 'fail'
-            download_message = "URLError on an image...trying next one..." + " Error: " + str(e)
+            download_message = f"URLError on an image...trying next one... Error: {e}"
             return_image_name = ''
             absolute_path = ''
 
         except ssl.CertificateError as e:
             download_status = 'fail'
-            download_message = "CertificateError on an image...trying next one..." + " Error: " + str(e)
+            download_message = f"CertificateError on an image...trying next one... Error: {e}"
             return_image_name = ''
             absolute_path = ''
 
         except IOError as e:  # If there is any IOError
             download_status = 'fail'
-            download_message = "IOError on an image...trying next one..." + " Error: " + str(e)
+            download_message = f"IOError on an image...trying next one... Error: {e}"
             return_image_name = ''
             absolute_path = ''
 
         except IncompleteRead as e:
             download_status = 'fail'
-            download_message = "IncompleteReadError on an image...trying next one..." + " Error: " + str(e)
+            download_message = f"IncompleteReadError on an image...trying next one... Error: {e}"
             return_image_name = ''
             absolute_path = ''
 
@@ -805,9 +803,7 @@ class googleimagesdownload:
                 page = page[end_content:]
             i += 1
         if count < limit:
-            print("\n\nUnfortunately all " + str(
-                limit) + " could not be downloaded because some images were not downloadable. " + str(
-                count-1) + " is all we got for this search filter!")
+            print(f"\n\nUnfortunately all {limit} could not be downloaded because some images were not downloadable. {count-1} is all we got for this search filter!")
         return items,errorCount,abs_path
 
     def _parse_AF_initDataCallback(self, page):
@@ -855,7 +851,7 @@ class googleimagesdownload:
                     json_obj = json.loads(data_str)
                     return json_obj
                 except Exception as e:
-                    print('WARNING:', e, t)
+                    print(f'WARNING: {e} {t}')
                     return {}
 
             entries = list(map(parse_json, scriptTexts))
@@ -897,7 +893,7 @@ class googleimagesdownload:
                     return rg_meta
 
                 except Exception as e:
-                    print("WARNING:", e, meta)
+                    print(f"WARNING: {e} {meta}")
 
             metas = list(filter(None, map(meta_array2meta_dict, imgMetas)))
             return metas
@@ -979,13 +975,13 @@ class googleimagesdownload:
 
         # Additional words added to keywords
         if arguments['suffix_keywords']:
-            suffix_keywords = [" " + str(sk) for sk in arguments['suffix_keywords'].split(',')]
+            suffix_keywords = [f" {sk}" for sk in arguments['suffix_keywords'].split(',')]
         else:
             suffix_keywords = ['']
 
         # Additional words added to keywords
         if arguments['prefix_keywords']:
-            prefix_keywords = [str(sk) + " " for sk in arguments['prefix_keywords'].split(',')]
+            prefix_keywords = [f"{sk} " for sk in arguments['prefix_keywords'].split(',')]
         else:
             prefix_keywords = ['']
 
@@ -1030,12 +1026,12 @@ class googleimagesdownload:
             for sky in suffix_keywords:             # 2.for every suffix keywords
                 i = 0
                 while i < len(search_keyword):      # 3.for every main keyword
-                    iteration = "\n" + "Item no.: " + str(i + 1) + " -->" + " Item name = " + (pky) + (search_keyword[i]) + (sky)
+                    iteration = f"\nItem no.: {i + 1} --> Item name = {pky}{search_keyword[i]}{sky}"
                     if not arguments["silent_mode"]:
                         print(iteration.encode('raw_unicode_escape').decode('utf-8'))
                         print("Evaluating...")
                     else:
-                        print("Downloading images for: " + (pky) + (search_keyword[i]) + (sky) + " ...")
+                        print(f"Downloading images for: {pky}{search_keyword[i]}{sky} ...")
                     search_term = pky + search_keyword[i] + sky
 
                     if arguments['image_directory']:
@@ -1073,7 +1069,7 @@ class googleimagesdownload:
                                 os.makedirs("logs")
                         except OSError as e:
                             print(e)
-                        json_file = open("logs/"+search_keyword[i]+".json", "w")
+                        json_file = open(os.path.join("logs",f"{search_keyword[i]}.json", "w")
                         json.dump(items, json_file, indent=4, sort_keys=True)
                         json_file.close()
 
@@ -1083,7 +1079,7 @@ class googleimagesdownload:
                         tabs = self.get_all_tabs(raw_html)
                         for key, value in tabs.items():
                             final_search_term = (search_term + " - " + key)
-                            print("\nNow Downloading - " + final_search_term)
+                            print(f"\nNow Downloading - {final_search_term}")
                             if limit < 101:
                                 new_raw_html = self.download_page(value)  # download page
                             else:
@@ -1107,10 +1103,10 @@ def remove_illegal_characters(string):
     try:
         name = badchars.sub('_', string)
         if badnames.match(name):
-            name = '_' + name
+            name = f"_{name}"
         return name
     except Exception as e:
-        print("ERROR cleaning filename:", e)
+        print(f"ERROR cleaning filename: {e}")
     return string
 
 
@@ -1133,8 +1129,8 @@ def main():
         total_time = t1 - t0  # Calculating the total time required to crawl, find and download all the links of 60,000 images
         if not arguments["silent_mode"]:
             print("\nEverything downloaded!")
-            print("Total errors: " + str(total_errors))
-            print("Total time taken: " + str(total_time) + " Seconds")
+            print(f"Total errors: {total_errors}")
+            print(f"Total time taken: {total_time} Seconds")
 
 if __name__ == "__main__":
     main()

--- a/videos/scrapers/imdb.py
+++ b/videos/scrapers/imdb.py
@@ -35,14 +35,14 @@ def search_imdb(actor_to_search, alias, force):
     # https://www.iafd.com/results.asp?searchtype=comprehensive&searchstring=isis+love
     if alias:
         name_with_plus = alias.name.replace(' ', '+')
-        print("Searching IMDB for: " + actor_to_search.name + " alias: " + alias.name)
+        print(f"Searching IMDB for: {actor_to_search.name} alias: {alias.name}")
         name = alias.name
     else:
         name_with_plus = name.replace(' ', '+')
-        print("Searching IMDB for: " + actor_to_search.name)
-        print("(" + name_with_plus + ")")
-    r = requests.get("https://www.imdb.com/search/name?name=" + name_with_plus + "&adult=include", verify=False)
-    print("https://www.imdb.com/search/name?name=" + name_with_plus + "&adult=include")
+        print(f"Searching IMDB for: {actor_to_search.name}")
+        print(f"({name_with_plus})")
+    r = requests.get(f"https://www.imdb.com/search/name?name={name_with_plus}&adult=include", verify=False)
+    print(f"https://www.imdb.com/search/name?name={name_with_plus}&adult=include")
     soup = BeautifulSoup(r.content, "html5lib")
     # link = soup.find_all("a", {"text": "Isis Love"})
     for soup_links in soup.find_all("h3", attrs={'class': 'lister-item-header'}):	#, class_="lister-item-header")
@@ -58,12 +58,12 @@ def search_imdb(actor_to_search, alias, force):
 
         if href_found:
             success = True
-            bio_page = urllib_parse.urljoin("https://www.imdb.com/", href_found) + '/bio?ref_=nm_ov_bio_sm'
-            imdb_id = href_found.replace("/name/","")
-            imdb_id = imdb_id.replace("/","")
-            print(actor_to_search.name + " was found on IMDB!")# + href_found + "ID " + imdb_id)
+            found_lnk = urllib_parse.urljoin("https://www.imdb.com/",href_found)
+            bio_page = f"{found_lnk}/bio?ref_=nm_ov_bio_sm"
+            imdb_id = href_found.replace("/name/","").replace("/","")
+            print(f"{actor_to_search.name} was found on IMDB!")# + href_found + "ID " + imdb_id)
             actor_to_search.imdb_id = imdb_id
-            print("Scraping biography from " + bio_page)
+            print(f"Scraping biography from {bio_page}")
             r = requests.get(bio_page, verify=False)
             soup = BeautifulSoup(r.content, "html5lib")
             soup_bio = soup.find("div", attrs={'class': 'soda'})
@@ -84,7 +84,7 @@ def search_imdb(actor_to_search, alias, force):
         else:
             #actor_to_search.last_lookup = datetime.datetime.now()
            #actor_to_search.save()
-            print(actor_to_search.name + " was not found on IMDB.")
+            print(f"{actor_to_search.name} was not found on IMDB.")
 		
         return success
 
@@ -94,7 +94,7 @@ def strip_bad_chars(name):
         if char in name:
             #print("Before: " + name)
             name = name.replace(char, "")
-            print("Adding Data: " + name)
+            print(f"Adding Data: {name}")
     return name
 
 def insert_aliases(actor_to_insert, aliases):
@@ -152,7 +152,7 @@ def main():
     print("test")
     for actor in Actor.objects.all():
 
-        print("Fetching info for: " + actor.name)
+        print(f"Fetching info for: {actor.name}")
         time.sleep(10)
         sucess = search_imdb_with_force_flag(actor, True)
         if not sucess:

--- a/videos/scrapers/tmdb.py
+++ b/videos/scrapers/tmdb.py
@@ -21,7 +21,7 @@ MEDIA_PATH = os.path.join('videos', 'media')
 
 def search_person(actor_in_question, alias, force):
     sucesss = False
-    print("Looking for: " + actor_in_question.name + "                                                           \r",end="")
+    print(f"Looking for: {actor_in_question.name}                                                           \r",end="")
     search = tmdb.Search()
     # response = search.person(query="Harmony Rose", include_adult='true')
     if not alias:
@@ -43,10 +43,10 @@ def search_person(actor_in_question, alias, force):
             person_info = person.info()
 ### This is just for image downloading.
             if person_info['profile_path'] is not None:
-                picture_link = "https://image.tmdb.org/t/p/original/" + person_info['profile_path']
+                picture_link = f"https://image.tmdb.org/t/p/original/{person_info['profile_path']}"
                 if aux.url_is_alive(picture_link):
                     #if actor_in_question.thumbnail == const.UNKNOWN_PERSON_IMAGE_PATH or force:
-                    print("Trying to get image from TMDB: " + picture_link +"\r",end="")
+                    print(f"Trying to get image from TMDB: {picture_link}\r",end="")
                     if aux.url_is_alive(picture_link):
                         aux.save_actor_profile_image_from_web(picture_link,actor_in_question,force)
                     else:
@@ -62,30 +62,30 @@ def search_person(actor_in_question, alias, force):
                 actor_in_question.description = ""
             if not person_info['birthday'] == "":
                 actor_in_question.date_of_birth = person_info['birthday']
-                print("Added Birthday to: " + actor_in_question.name)
+                print(f"Added Birthday to: {actor_in_question.name}")
             if not actor_in_question.gender:
                 person_gender = person_info['gender']
                 if person_gender == 2:
                     actor_in_question.gender = 'M'
-                    print("Added Gender to: " + actor_in_question.name+"\r",end="")
+                    print(f"Added Gender to: {actor_in_question.name}\r",end="")
                 elif person_gender == 1:
                     actor_in_question.gender = 'F'
-                    print("Added Gender to: " + actor_in_question.name+"\r",end="")
+                    print(f"Added Gender to: {actor_in_question.name}\r",end="")
             if person_info['homepage']:
                 actor_in_question.official_pages = person_info['homepage']
-                print("Added Homepage to: " + actor_in_question.name+"\r",end="")
+                print(f"Added Homepage to: {actor_in_question.name}\r",end="")
 
                 actor_in_question.tmdb_id = person_info['id']
                 actor_in_question.imdb_id = person_info['imdb_id']
 
             if actor_in_question.thumbnail == const.UNKNOWN_PERSON_IMAGE_PATH or force:
                 if person_info['profile_path'] is not None:
-                    picture_link = "https://image.tmdb.org/t/p/original/" + person_info['profile_path']
-                    print("Trying to get image from TMDB: " + picture_link+"\r",end="")
+                    picture_link = f"https://image.tmdb.org/t/p/original/{person_info['profile_path']}"
+                    print(f"Trying to get image from TMDB: {picture_link}\r",end="")
                     if aux.url_is_alive(picture_link):
                         aux.save_actor_profile_image_from_web(picture_link,actor_in_question,force)
                     else:
-                        print("Seems as there's no photo at this link."+"\r",end="")
+                        print("Seems as there's no photo at this link.\r",end="")
             for aka in person_aka:
                 aka = aka.lstrip()
                 aka = aka.rstrip()
@@ -106,7 +106,7 @@ def search_person(actor_in_question, alias, force):
             break
 
     if not sucesss:
-        print ("Actor: {} could not be found on TMDb".format(actor_in_question.name)+"\r")
+        print (f"Actor: {actor_in_question.name} could not be found on TMDb\r")
     return sucesss
 
 
@@ -121,12 +121,12 @@ def search_alias(actor_in_question, alias, force):
 
 def search_person_with_force_flag(actor_in_question, force):
     success = False
-    print("Looking for: " + actor_in_question.name+"\r",end="")
+    print(f"Looking for: {actor_in_question.name}\r",end="")
     if force:
         print("Force flag is true, ignoring last lookup")
         success = search_person(actor_in_question, None, force)
     elif not actor_in_question.last_lookup:
-        print("Actor: " + actor_in_question.name + " was not yet searched... Searching now!\r",end="")
+        print(f"Actor: {actor_in_question.name} was not yet searched... Searching now!\r",end="")
         success = search_person(actor_in_question, None, force)
 
     return success

--- a/videos/startup.py
+++ b/videos/startup.py
@@ -19,7 +19,7 @@ def maybeMoveConfigJson():
     dest = YAPO.settings.CONFIG_JSON
     if path.isfile(src):
         shutil.move(src, dest)
-        log.info("\n███ Your configuration file was moved to  ({0})! ███".format(dest))
+        log.info(f"\n███ Your configuration file was moved to  ({dest})! ███")
 
 
 def getSizeAll() -> str:
@@ -39,28 +39,21 @@ def getSizeAll() -> str:
 def sizeFormat(b: int) -> str:
 
     if b < 1000:
-        return "%i" % b + "B"
-    elif 1000 <= b < 1000000:
-        return "%.1f" % float(b / 1000) + "KB"
-    elif 1000000 <= b < 1000000000:
-        return "%.1f" % float(b / 1000000) + "MB"
-    elif 1000000000 <= b < 1000000000000:
-        return "%.1f" % float(b / 1000000000) + "GB"
-    elif 1000000000000 <= b:
-        return "%.1f" % float(b / 1000000000000) + "TB"
+        return f"{b}B"
+    elif b < 1000000:
+        return f"{b/1000:.1f}KB"
+    elif b < 1000000000:
+        return f"{b/1000000:.1f}MB"
+    elif b < 1000000000000:
+        return f"{b/1000000000:.1f}GB"
+    else:
+        return f"{b/1000000000000:.1f}TB"
 
 
 def write_actors_to_file():
     actors = Actor.objects.order_by("id")  # name
-    actors_string = ""
-    numactors = 0
-    for actor in actors:
-
-        if not (numactors == 0):
-            actors_string += "," + actor.name
-        else:
-            actors_string += actor.name
-        numactors += 1
+    actors_string = ",".join(actor.name for actor in actors)
+    numactors = len(actors)
 
     with open("actors.txt", "w") as file:
         file.write(actors_string)
@@ -70,13 +63,14 @@ def write_actors_to_file():
 
 
 def verCheck():
-    update = os.path.abspath(os.path.join(os.path.dirname(__file__), "..", "VERSION.md"))
+    #dirname of dirname of file results in parent directory
+    update = os.path.abspath(os.path.join(os.path.dirname(os.path.dirname(__file__)), "VERSION.md")
 
     if path.isfile(update):
         with open(update, "r") as verfile:
             ver = verfile.read()
         ver = str(ver).strip()
-        print("--- Version on disk: " + ver)
+        print(f"--- Version on disk: {ver}")
         try:
             remoteVer = requests.get(
                 "https://raw.githubusercontent.com/cooperdk/YAPO-e-plus/develop/VERSION.md"
@@ -116,16 +110,16 @@ def stats():
         sctag = str(row[0].total)
     # TODO assign that all values got read correctly and have a valid value!
 
-    print("\nCurrently, there are {0} videos registered in YAPO e+.\nThey take up {1} of disk space.".format(sce, str(size)))
-    print("There are {0} tags available for video clips.".format(sctag))
-    print("\nThere are {0} actors in the database.\nThese actors have {1} usable tags.\n\n".format(act, acttag))
+    print(f"\nCurrently, there are {sce} videos registered in YAPO e+.\nThey take up {size} of disk space.")
+    print(f"There are {sctag} tags available for video clips.")
+    print(f"\nThere are {act} actors in the database.\nThese actors have {acttag} usable tags.\n\n")
 
 def backupper():
     import YAPO.settings as settings
     src = settings.DATABASES['default']['NAME']
-    dest = os.path.abspath(os.path.join(os.path.dirname(__file__), "..", "db_BACKUP.sqlite3"))
+    dest = os.path.abspath(os.path.join(os.path.dirname(os.path.dirname(__file__)), "db_BACKUP.sqlite3"))
     shutil.copy(src, dest)
-    print("Performed a database backup to " + dest + "\n")
+    print(f"Performed a database backup to {dest}\n")
 
 
 def add_scene_to_folder_view(scene_to_add):
@@ -165,7 +159,7 @@ def recursive_add_folders(parent, folders, scene_to_add, path_with_ids):
             path_with_ids = []
             if not Folder.objects.filter(name=folders[0]):
                 temp = Folder.objects.create(name=folders[0])
-                print("Created virtual folder: " + temp.name)
+                print(f"Created virtual folder: {temp.name}")
                 parent = Folder.objects.get(name=folders[0])
                 if parent.last_folder_name_only is None:
                     parent.last_folder_name_only = folders[0]
@@ -208,7 +202,7 @@ def recursive_add_folders(parent, folders, scene_to_add, path_with_ids):
 
             if not if_in_children:
                 parent = Folder.objects.create(name=folder_to_add, parent=parent)
-                print("Created virtual folder: " + parent.name)
+                print(f"Created virtual folder: {parent.name}")
                 if parent.last_folder_name_only is None:
                     parent.last_folder_name_only = folders[0]
                 parent.save()
@@ -232,10 +226,7 @@ def recursive_add_folders(parent, folders, scene_to_add, path_with_ids):
         if not parent.scenes.filter(name=scene_to_add.name):
             parent.scenes.add(scene_to_add)
             print(
-                "Added Scene: "
-                + scene_to_add.name
-                + " to virtual folder "
-                + parent.name
+                f"Added Scene: {scene_to_add.name} to virtual folder {parent.name}"
             )
             parent.save()
 
@@ -253,8 +244,7 @@ def getStarted():
     cpu = aux.getCPU()
     cpucnt = aux.getCPUCount()
     global videoProcessing
-    print("\nYou have " + str(mem) + " GB available. CPU speed is " +
-          str(cpu) + " GHz and you have " + str(cpucnt) + " cores available.")
+    print(f"\nYou have {mem} GB available. CPU speed is {cpu} GHz and you have {cpucnt} cores available.")
     if mem <= 1:
         print("Since you have only about a gigabyte of memory, video processing will be disabled.")
         videoProcessing = False

--- a/videos/videosheet/videosheet.py
+++ b/videos/videosheet/videosheet.py
@@ -200,8 +200,8 @@ class MediaInfo(object):
 
         if verbose:
             print(self.filename)
-            print("%sx%s" % (self.sample_width, self.sample_height))
-            print("%sx%s" % (self.display_width, self.display_height))
+            print(f"{self.sample_width}x{self.sample_height}")
+            print(f"{self.display_width}x{self.display_height}")
             print(self.duration)
             print(self.size)
 
@@ -232,9 +232,9 @@ class MediaInfo(object):
         """
         for unit in ["", "KB", "MB", "GB", "TB", "PB", "EB", "ZB"]:
             if abs(num) < 1024.0:
-                return "%3.1f %s" % (num, unit)
+                return f"{num:3.1f} {unit}"
             num /= 1024.0
-        return "%.1f %s" % (num, "YB")
+        return f"{num:.1f} YB"
 
     def find_video_stream(self):
         """Find the first stream which is a video stream
@@ -359,20 +359,19 @@ class MediaInfo(object):
         duration = ""
 
         if hours > 0:
-            duration += "%s:" % (int(hours),)
+            duration += f"{hours}:"
 
-        duration += "%s:%s" % (
-            str(int(minutes)).zfill(2),
-            str(int(math.floor(remaining_seconds))).zfill(2),
-        )
+        duration += f"{minutes:02d}:{remaining_seconds:02d}"
 
         if show_centis or show_millis:
             coeff = 1000 if show_millis else 100
-            digits = 3 if show_millis else 2
             centis = math.floor(
                 (remaining_seconds - math.floor(remaining_seconds)) * coeff
             )
-            duration += ".%s" % (str(int(centis)).zfill(digits))
+            if show_millis:
+	            duration += f".{centis:03d}"
+	        else:
+	            duration += f".{centis:02d}"
 
         return duration
 
@@ -619,11 +618,11 @@ class MediaCapture(object):
             "-vframes",
             "1",
             "-s",
-            "%sx%s" % (width, height),
+            f"{width}x{height}",
         ]
 
         if self.frame_type is not None:
-            select_args = ["-vf", "select='eq(frame_type\\," + self.frame_type + ")'"]
+            select_args = ["-vf", f"select='eq(frame_type\\,{self.frame_type})'"]
 
         if self.frame_type == "key":
             select_args = ["-vf", "select=key"]
@@ -834,7 +833,7 @@ def select_sharpest_images(media_info, media_capture, args):
         # use multiple threads
         with ThreadPoolExecutor() as executor:
             for i, timestamp_tuple in enumerate(timestamps):
-                status = "Starting task... {}/{}".format(i + 1, args.num_samples)
+                status = f"Starting task... {i+1}/{args.num_samples}"
                 print(status, end="\r")
                 suffix = ".jpg"  # faster processing time
                 future = executor.submit(
@@ -849,7 +848,7 @@ def select_sharpest_images(media_info, media_capture, args):
             print()
 
             for i, future in enumerate(futures):
-                status = "Sampling... {}/{}".format(i + 1, args.num_samples)
+                status = f"Sampling... {i+1}/{args.num_samples}"
                 print(status, end="\r")
                 frame = future.result()
                 blurs += [frame]
@@ -857,7 +856,7 @@ def select_sharpest_images(media_info, media_capture, args):
     else:
         # grab captures sequentially
         for i, timestamp_tuple in enumerate(timestamps):
-            status = "Sampling... {}/{}".format(i + 1, args.num_samples)
+            status = f"Sampling... {i+1}/{args.num_samples}"
             print(status, end="\r")
             suffix = ".png"  # arguably higher image quality
             frame = do_capture(
@@ -1090,7 +1089,7 @@ def load_font(args, font_path, font_size, default_font_path):
     if font_path == default_font_path:
         for font in fonts:
             if args.is_verbose:
-                print("Trying to load font:", font)
+                print(f"Trying to load font: {font}")
             if os.path.exists(font):
                 try:
                     return ImageFont.truetype(font, font_size)
@@ -1102,7 +1101,7 @@ def load_font(args, font_path, font_size, default_font_path):
         try:
             return ImageFont.truetype(font_path, font_size)
         except OSError:
-            error_exit("Cannot load font: {}".format(font_path))
+            error_exit(f"Cannot load font: {font_path}")
 
 
 def compose_contact_sheet(media_info, frames, args):
@@ -1324,15 +1323,15 @@ def cleanup(frames, args):
     """Delete temporary captures
     """
     if args.is_verbose:
-        print("Deleting {} temporary frames...".format(len(frames)))
+        print(f"Deleting {len(frames)} temporary frames...")
     for frame in frames:
         try:
             if args.is_verbose:
-                print("Deleting {} ...".format(frame.filename))
+                print(f"Deleting {frame.filename} ...")
             os.unlink(frame.filename)
         except Exception as e:
             if args.is_verbose:
-                print("[Error] Failed to delete {}".format(frame.filename))
+                print(f"[Error] Failed to delete {frame.filename}")
                 print(e)
 
 
@@ -1376,9 +1375,7 @@ def metadata_position_type(string):
     if lowercase_position in valid_metadata_positions:
         return lowercase_position
     else:
-        error = "Metadata header position must be one of %s" % (
-            str(valid_metadata_positions,)
-        )
+        error = f"Metadata header position must be one of {valid_metadata_positions}"
         raise argparse.ArgumentTypeError(error)
 
 
@@ -1422,10 +1419,7 @@ def timestamp_position_type(string):
     try:
         return getattr(TimestampPosition, string)
     except AttributeError:
-        error = "Invalid timestamp position: %s. Valid positions are: %s" % (
-            string,
-            VALID_TIMESTAMP_POSITIONS,
-        )
+        error = f"Invalid timestamp position: {string}. Valid positions are: {VALID_TIMESTAMP_POSITIONS}"
         raise argparse.ArgumentTypeError(error)
 
 
@@ -1441,7 +1435,7 @@ def interval_type(string):
     cal = parsedatetime.Calendar()
     interval = cal.parseDT(string, sourceTime=m)[0] - m
     if interval == m:
-        error = "Invalid interval format: {}".format(string)
+        error = f"Invalid interval format: {string}"
         raise argparse.ArgumentTypeError(error)
 
     return interval
@@ -1457,7 +1451,7 @@ def comma_separated_string_type(string):
 
 def error(message):
     """Print an error message."""
-    print("[ERROR] %s" % (message,))
+    print(f"[ERROR] {message}")
 
 
 def error_exit(message):
@@ -1866,7 +1860,7 @@ def main():
                 raise
             else:
                 print(
-                    "[WARN]: failed to process {} ... skipping.".format(filepath),
+                    f"[WARN]: failed to process {filepath} ... skipping.",
                     file=sys.stderr,
                 )
 
@@ -1896,39 +1890,39 @@ def process_file(path, args):
     """Generate a video contact sheet for the file at given path
     """
     if args.is_verbose:
-        print("Considering {}...".format(path))
+        print(f"Considering {path}...")
 
     args = deepcopy(args)
 
     if not os.path.exists(path):
         if args.ignore_errors:
-            print("File does not exist, skipping: {}".format(path))
+            print(f"File does not exist, skipping: {path}")
             return
         else:
-            error_message = "File does not exist: {}".format(path)
+            error_message = f"File does not exist: {path}"
             error_exit(error_message)
 
     file_extension = path.lower().split(".")[-1]
     if file_extension in args.exclude_extensions:
-        print("[WARN] Excluded extension {}. Skipping.".format(file_extension))
+        print(f"[WARN] Excluded extension {file_extension}. Skipping.")
         return
 
     output_path = args.output_path
     if not output_path:
-        output_path = path + "." + args.image_format
+        output_path = f"{path}.{args.image_format}"
     elif os.path.isdir(output_path):
         output_path = os.path.join(
-            output_path, os.path.basename(path) + "." + args.image_format
+            output_path, f"{os.path.basename(path)}.{args.image_format}"
         )
 
     if args.no_overwrite:
         if os.path.exists(output_path):
             print(
-                "[INFO] contact-sheet already exists, skipping: {}".format(output_path)
+                f"[INFO] contact-sheet already exists, skipping: {output_path}"
             )
             return
 
-    print("Processing {}...".format(path))
+    print(f"Processing {path}...")
 
     if args.interval is not None and args.manual_timestamps is not None:
         error_exit("Cannot use --interval and --manual at the same time.")
@@ -2038,15 +2032,11 @@ def process_file(path, args):
     thumbnail_output_path = args.thumbnail_output_path
     if thumbnail_output_path is not None:
         os.makedirs(thumbnail_output_path, exist_ok=True)
-        print("Copying thumbnails to {} ...".format(thumbnail_output_path))
+        print(f"Copying thumbnails to {thumbnail_output_path} ...")
         for i, frame in enumerate(selected_frames):
             print(frame.filename)
             thumbnail_file_extension = frame.filename.lower().split(".")[-1]
-            thumbnail_filename = "{filename}.{number}.{extension}".format(
-                filename=os.path.basename(path),
-                number=str(i).zfill(4),
-                extension=thumbnail_file_extension,
-            )
+            thumbnail_filename = f"{os.path.basename(path)}.{i:04d}.{thumbnail_file_extension}"
             thumbnail_destination = os.path.join(
                 thumbnail_output_path, thumbnail_filename
             )
@@ -2056,7 +2046,7 @@ def process_file(path, args):
     cleanup(temp_frames, args)
 
     if not is_save_successful:
-        error_exit("Unsupported image format: %s." % (args.image_format,))
+        error_exit(f"Unsupported image format: {args.image_format}.")
 
 
 if __name__ == "__main__":

--- a/videos/views.py
+++ b/videos/views.py
@@ -59,10 +59,7 @@ def get_scenes_in_folder_recursive(folder, scene_list):
 
 
 def onlyChars(input):
-    valids = ""
-    for character in input:
-        if character.isalpha():
-            valids += character
+    valids = "".join(character for character in input if character.isalpha())
     return valids
 
 
@@ -117,13 +114,13 @@ def search_in_get_queryset(original_queryset, request):
             #             qs_list = tmp_list
 
             if search_string.startswith("<"):
-                string_keyarg = search_field + "__lte"
+                string_keyarg = "{search_field}__lte"
                 search_string = search_string.replace("<", "")
             elif search_string.startswith(">"):
-                string_keyarg = search_field + "__gte"
+                string_keyarg = "{search_field}__gte"
                 search_string = search_string.replace(">", "")
             else:
-                string_keyarg = search_field + "__icontains"
+                string_keyarg = f"{search_field}__icontains"
 
             if search_string:
                 original_queryset = original_queryset.filter(
@@ -298,7 +295,7 @@ def scrape_all_actors(force):
                     scraper_freeones.search_freeones_with_force_flag(actor, True)
                     print("Finished Freeones search")
             else:
-                print(actor.name + " was already searched...                                                                        \r",end="")
+                print("{actor.name} was already searched...                                                                        \r",end="")
         else:
 
             print("Searching in TMDb")
@@ -330,10 +327,9 @@ def tag_all_scenes(ignore_last_lookup):
 
             scene_tag_to_add = SceneTag.objects.get(name=actorTag.name)
             actorTag.scene_tags.add(scene_tag_to_add)
+            scenetag=SceneTag.objects.filter(name=actorTag.name)
             print(
-                "Added scene tag {} to actor tag {}".format(
-                    SceneTag.objects.filter(name=actorTag.name), actorTag.name
-                )
+                f"Added scene tag {scenetag} to actor tag {actorTag.name}"
             )
 
     filename_parser.parse_all_scenes(False)
@@ -356,10 +352,9 @@ def tag_all_scenes_ignore_last_lookup(ignore_last_lookup):
 
             scene_tag_to_add = SceneTag.objects.get(name=actorTag.name)
             actorTag.scene_tags.add(scene_tag_to_add)
+            scenetag=SceneTag.objects.filter(name=actorTag.name)
             print(
-                "Added scene tag {} to actor tag {}".format(
-                    SceneTag.objects.filter(name=actorTag.name), actorTag.name
-                )
+                f"Added scene tag {scenetag} to actor tag {actorTag.name}"
             )
 
     filename_parser.parse_all_scenes(True)
@@ -397,7 +392,7 @@ class ScrapeActor(views.APIView):
         else:
             force = False
         print("Now entering the scrape actor API REST view")
-        print("Scanning for " + Actor.objects.get(pk=actor_id).name + " on " + search_site)
+        print(f"Scanning for {Actor.objects.get(pk=actor_id).name} on {search_site}")
 
         if search_site == "TMDb":
             actor_to_search = Actor.objects.get(pk=actor_id)
@@ -460,21 +455,17 @@ def permenatly_delete_scene_and_remove_from_db(scene):
     success_delete_media_path = False
     try:
         os.remove(scene.path_to_file)
-        print("Successfully deleted scene '{}'".format(scene.path_to_file))
+        print(f"Successfully deleted scene '{scene.path_to_file}'")
         success_delete_file = True
     except OSError as e:
         if e.errno == errno.ENOENT:
             print(
-                "File {} already deleted! [Err No:{}, Err File:{} Err:{}]".format(
-                    scene.path_to_file, e.errno, e.filename, e.strerror
-                )
+                f"File {scene.path_to_file} already deleted! [Err No:{e.errno}, Err File:{e.filename} Err:{e.strerror}]"
             )
             success_delete_file = True
         else:
             print(
-                "Got OSError while trying to delete {} : Error number:{} Error Filename:{} Error:{}".format(
-                    scene.path_to_file, e.errno, e.filename, e.strerror
-                )
+                f"Got OSError while trying to delete {scene.path_to_file} : Error number:{e.errno} Error Filename:{e.filename} Error:{e.strerror}"
             )
 
     media_path = os.path.relpath(
@@ -483,22 +474,20 @@ def permenatly_delete_scene_and_remove_from_db(scene):
     print(os.path.dirname(os.path.abspath(__file__)))
     try:
         shutil.rmtree(media_path)
-        print("Deleted '{}'".format(media_path))
+        print(f"Deleted '{media_path}'")
         success_delete_media_path = True
     except OSError as e:
         if e.errno == errno.ENOENT:
-            print("Directory '{}' already deleted".format(media_path))
+            print(f"Directory '{media_path}' already deleted")
             success_delete_media_path = True
         else:
             print(
-                "Got OSError while trying to delete {} : Error number:{} Error Filename:{} Error:{}".format(
-                    scene.path_to_file, e.errno, e.filename, e.strerror
-                )
+                f"Got OSError while trying to delete {scene.path_to_file} : Error number:{e.errno} Error Filename:{e.filename} Error:{e.strerror}"
             )
 
     if success_delete_file and success_delete_media_path:
         scene.delete()
-        print("Removed '{}' from database".format(scene.name))
+        print(f"Removed '{scene.name}' from database")
 
 
 def checkDupeHash(hash):
@@ -534,18 +523,14 @@ def tag_multiple_items(request):
                         scene_to_update = Scene.objects.get(pk=x)
                         scene_to_update.websites.add(website_to_add)
                         print(
-                            "Added Website '{}' to scene '{}'".format(
-                                website_to_add.name, scene_to_update.name
-                            )
+                            f"Added Website '{website_to_add.name}' to scene '{scene_to_update.name}'"
                         )
 
                         if website_to_add.scene_tags.count() > 0:
                             for tag in website_to_add.scene_tags.all():
                                 scene_to_update.scene_tags.add(tag)
                                 print(
-                                    "Added Scene Tag '{}' to scene '{}'".format(
-                                        tag.name, scene_to_update.name
-                                    )
+                                    f"Added Scene Tag '{tag.name}' to scene '{scene_to_update.name}'"
                                 )
 
                         scene_to_update.save()
@@ -554,18 +539,14 @@ def tag_multiple_items(request):
                         scene_to_update = Scene.objects.get(pk=x)
                         scene_to_update.websites.remove(website_to_add)
                         print(
-                            "Removed Website '{}' from scene '{}'".format(
-                                website_to_add.name, scene_to_update.name
-                            )
+                            f"Removed Website '{website_to_add.name}' from scene '{scene_to_update.name}'"
                         )
                         if website_to_add.scene_tags.count() > 0:
                             for tag in website_to_add.scene_tags.all():
                                 if tag in scene_to_update.scene_tags.all():
                                     scene_to_update.scene_tags.remove(tag)
                                     print(
-                                        "Removed Scene Tag '{}' from scene '{}'".format(
-                                            tag.name, scene_to_update.name
-                                        )
+                                        f"Removed Scene Tag '{tag.name}' from scene '{scene_to_update.name}'"
                                     )
                         scene_to_update.save()
 
@@ -581,9 +562,7 @@ def tag_multiple_items(request):
                         scene_to_update.scene_tags.add(scene_tag_to_add)
                         scene_to_update.save()
                         print(
-                            "Added Scene Tag '{}' to scene '{}'".format(
-                                scene_tag_to_add.name, scene_to_update.name
-                            )
+                            f"Added Scene Tag '{scene_tag_to_add.name}' to scene '{scene_to_update.name}'"
                         )
 
                 if params["addOrRemove"] == "remove":
@@ -592,9 +571,7 @@ def tag_multiple_items(request):
                         scene_to_update.scene_tags.remove(scene_tag_to_add)
                         scene_to_update.save()
                         print(
-                            "Removed Scene Tag '{}' from scene '{}'".format(
-                                scene_tag_to_add.name, scene_to_update.name
-                            )
+                            f"Removed Scene Tag '{scene_tag_to_add.name}' from scene '{scene_to_update.name}'"
                         )
             elif params["patchType"] == "actors":
                 actor_id = params["patchData"][0]
@@ -607,9 +584,7 @@ def tag_multiple_items(request):
                         scene_to_update = Scene.objects.get(pk=x)
                         scene_to_update.actors.add(actor_to_add)
                         print(
-                            "Added Actor '{}' to scene '{}'".format(
-                                actor_to_add.name, scene_to_update.name
-                            )
+                            f"Added Actor '{actor_to_add.name}' to scene '{scene_to_update.name}'"
                         )
 
                         if actor_to_add.actor_tags.count() > 0:
@@ -618,10 +593,7 @@ def tag_multiple_items(request):
                                     actor_tag.scene_tags.first()
                                 )
                                 print(
-                                    "Added Scene Tag '{}' to scene '{}'".format(
-                                        actor_tag.scene_tags.first().name,
-                                        scene_to_update.name,
-                                    )
+                                    f"Added Scene Tag '{actor_tag.scene_tags.first().name}' to scene '{scene_to_update.name}'"
                                 )
 
                         scene_to_update.save()
@@ -631,9 +603,7 @@ def tag_multiple_items(request):
                         scene_to_update = Scene.objects.get(pk=x)
                         scene_to_update.actors.remove(actor_to_add)
                         print(
-                            "Removed Actor '{}' from scene '{}'".format(
-                                actor_to_add.name, scene_to_update.name
-                            )
+                            f"Removed Actor '{actor_to_add.name}' from scene '{scene_to_update.name}'"
                         )
 
                         if actor_to_add.actor_tags.count() > 0:
@@ -646,10 +616,7 @@ def tag_multiple_items(request):
                                         actor_tag.scene_tags.first()
                                     )
                                     print(
-                                        "Removed Scene Tag '{}' to scene '{}'".format(
-                                            actor_tag.scene_tags.first().name,
-                                            scene_to_update.name,
-                                        )
+                                        f"Removed Scene Tag '{actor_tag.scene_tags.first().name}' to scene '{scene_to_update.name}'"
                                     )
                         scene_to_update.save()
 
@@ -666,9 +633,7 @@ def tag_multiple_items(request):
                         scene_to_update = Scene.objects.get(pk=x)
                         scene_to_update.delete()
                         print(
-                            "Removed scene '{}' from database".format(
-                                scene_to_update.name
-                            )
+                            f"Removed scene '{scene_to_update.name}' from database"
                         )
 
             elif params["patchType"] == "playlists":
@@ -682,9 +647,7 @@ def tag_multiple_items(request):
                         scene_to_update = Scene.objects.get(pk=x)
                         scene_to_update.playlists.add(playlist_to_add)
                         print(
-                            "Scene '{}' was added to playlist '{}'".format(
-                                scene_to_update.name, playlist_to_add.name
-                            )
+                            f"Scene '{scene_to_update.name}' was added to playlist '{playlist_to_add.name}'"
                         )
                         scene_to_update.save()
                 if params["addOrRemove"] == "remove":
@@ -692,9 +655,7 @@ def tag_multiple_items(request):
                         scene_to_update = Scene.objects.get(pk=x)
                         scene_to_update.playlists.remove(playlist_to_add)
                         print(
-                            "Scene '{}' was removed to playlist '{}'".format(
-                                scene_to_update.name, playlist_to_add.name
-                            )
+                            f"Scene '{scene_to_update.name}' was removed to playlist '{playlist_to_add.name}'"
                         )
                         scene_to_update.save()
 
@@ -708,9 +669,7 @@ def tag_multiple_items(request):
                     # scene_to_update[patch_type] = patch_data
 
                     print(
-                        "Set scene's '{}' attribute '{}' to '{}'".format(
-                            scene_to_update, patch_type, patch_data
-                        )
+                        f"Set scene's '{scene_to_update}' attribute '{patch_type}' to '{patch_data}'"
                     )
                     scene_to_update.save()
 
@@ -727,9 +686,7 @@ def tag_multiple_items(request):
                         actor_to_update.actor_tags.add(actor_tag_to_add)
                         actor_to_update.save()
                         print(
-                            "Added Actor Tag '{}' to actor {}".format(
-                                actor_tag_to_add.name, actor_to_update.name
-                            )
+                            f"Added Actor Tag '{actor_tag_to_add.name}' to actor {actor_to_update.name}"
                         )
                 elif params["addOrRemove"] == "remove":
 
@@ -738,9 +695,7 @@ def tag_multiple_items(request):
                         actor_to_update.actor_tags.remove(actor_tag_to_add)
                         actor_to_update.save()
                         print(
-                            "Removed Actor Tag '{}' to actor {}".format(
-                                actor_tag_to_add.name, actor_to_update.name
-                            )
+                            f"Removed Actor Tag '{actor_tag_to_add.name}' to actor {actor_to_update.name}"
                         )
             else:
                 actors_to_update = params["itemsToUpdate"]
@@ -752,9 +707,7 @@ def tag_multiple_items(request):
                     # scene_to_update[patch_type] = patch_data
 
                     print(
-                        "Set actors's '{}' attribute '{}' to '{}'".format(
-                            actor_to_update, patch_type, patch_data
-                        )
+                        f"Set actors's '{actor_to_update}' attribute '{patch_type}' to '{patch_data}'"
                     )
                     actor_to_update.save()
 
@@ -772,9 +725,7 @@ def clean_dir(type_of_model_to_clean):
     ):
 
         print(
-            "Checking {} folder {} out of {}".format(
-                type_of_model_to_clean, index, number_of_folders
-            )
+            f"Checking {type_of_model_to_clean} folder {index} out of {number_of_folders}"
         )
         try:
             dir_in_path_int = int(dir_in_path)
@@ -787,9 +738,7 @@ def clean_dir(type_of_model_to_clean):
                         const.MEDIA_PATH, type_of_model_to_clean, dir_in_path
                     )
                     print(
-                        "Actor id {} is not in the database... Deleting folder {}".format(
-                            dir_in_path_int, dir_to_delete
-                        )
+                        f"Actor id {dir_in_path_int} is not in the database... Deleting folder {dir_to_delete}"
                     )
                     shutil.rmtree(dir_to_delete)
             elif type_of_model_to_clean == "scenes":
@@ -801,18 +750,14 @@ def clean_dir(type_of_model_to_clean):
                         const.MEDIA_PATH, type_of_model_to_clean, dir_in_path
                     )
                     print(
-                        "Scene id {} is not in the database... Deleting folder {}".format(
-                            dir_in_path_int, dir_to_delete
-                        )
+                        f"Scene id {dir_in_path_int} is not in the database... Deleting folder {dir_to_delete}"
                     )
                     shutil.rmtree(dir_to_delete)
             index += 1
 
         except ValueError:
             print(
-                "Dir name '{}' Could not be converted to an integer, skipping...".format(
-                    dir_in_path
-                )
+                f"Dir name '{dir_in_path}' Could not be converted to an integer, skipping..."
             )
             index += 1
             pass
@@ -898,9 +843,7 @@ def settings(request):
                     # print("Checked " + str(anumber) + "...\n")
                     if checkDupeHash(scene_1.hash) > 1:
                         print(
-                            "Scene "
-                            + str(scene_1.id)
-                            + " has at least one dupe, running the dupe scanner...\n"
+                            f"Scene {scene_1.id} has at least one dupe, running the dupe scanner...\n"
                         )
                         for scene_2 in Scene.objects.all():
                             if not scene_1.pk == scene_2.pk:
@@ -911,12 +854,7 @@ def settings(request):
                                 #    str(scene_2.id) + " - " + scene_2.name + "\nFile path: " + scene_2.path_to_file)
                                 if scene_2.hash == scene_1.hash:
                                     print(
-                                        "Confirmed! Duplicate scene info:\n "
-                                        + str(scene_2.id)
-                                        + " - "
-                                        + scene_2.path_to_file
-                                        + "\nHash: "
-                                        + scene_2.hash
+                                        f"Confirmed! Duplicate scene info:\n {scene_2.id} - {scene_2.path_to_file}\nHash: {scene_2.hash}"
                                     )
                                     # print("Passing ID " + str(scene_2.id) + " to delete function...")
                                     permenatly_delete_scene_and_remove_from_db(scene_2)
@@ -935,12 +873,10 @@ def settings(request):
                 counter = 1
                 print("Cleaning Scenes...")  # CooperDK This was enabled
                 for scene in scenes:
-                    print("Checking scene {} out of {}".format(counter, count))
+                    print(f"Checking scene {counter} out of {count}")
                     if not os.path.isfile(scene.path_to_file):
                         print(
-                            "File for scene {} does not exist in path {}".format(
-                                scene.name, scene.path_to_file
-                            )
+                            f"File for scene {scene.name} does not exist in path {scene.path_to_file}"
                         )
                         permenatly_delete_scene_and_remove_from_db(scene)
                     counter += 1
@@ -952,10 +888,10 @@ def settings(request):
                 count = aliases.count()
                 counter = 1
                 for alias in aliases:
-                    print("Checking Alias {} out of {}".format(counter, count))
+                    print(f"Checking Alias {counter} out of {count}")
                     if alias.actors.count() == 0:
                         alias.delete()
-                        print("Alias {} has no actor... deleting".format(alias.name))
+                        print(f"Alias {alias.name} has no actor... deleting")
                     counter += 1
                 print("Finished cleaning aliases...")
 
@@ -1022,17 +958,15 @@ def add_comma_seperated_items_to_db(string_of_comma_seperated_items, type_of_ite
                 if not ActorAlias.objects.filter(name=object_to_insert.name):
                     object_to_insert.save()
                     print(
-                        "Added {} {} To db".format(type_of_item, object_to_insert.name)
+                        f"Added {type_of_item} {object_to_insert.name} To db"
                     )
             else:
                 object_to_insert.save()
-                print("Added {} {} To db".format(type_of_item, object_to_insert.name))
+                print(f"Added {type_of_item} {object_to_insert.name} To db")
         except django.db.IntegrityError as e:
             # content = {'something whent wrong': e}
             print(
-                "{} while trying to add {} {}".format(
-                    e, type_of_item, object_to_insert.name
-                )
+                f"{e} while trying to add {type_of_item} {object_to_insert.name}"
             )
             # return Response(content, status=status.HTTP_500_INTERNAL_SERVER_ERROR)
 
@@ -1058,14 +992,10 @@ class AddItems(views.APIView):
                         local_scene_folder.save()
                     except django.db.IntegrityError as e:
                         print(
-                            "{} while trying to add {} to folder list".format(
-                                e, local_scene_folder.name
-                            )
+                            f"{e} while trying to add {local_scene_folder.name} to folder list"
                         )
                     print(
-                        "Added folder {} to folder list...".format(
-                            local_scene_folder.name
-                        )
+                        f"Added folder {local_scene_folder.name} to folder list..."
                     )
                 else:
                     content = {"Path does not exist!": "Can't find path!"}
@@ -1098,34 +1028,26 @@ def play_scene_vlc(scene, random):
     scene.play_count += 1
     scene.date_last_played = datetime.datetime.now()
     print(
-        "Play count for scene '{}' is now '{}' and the date the scene was last played is '{}'".format(
-            scene.name, scene.play_count, scene.date_last_played
-        )
+        f"Play count for scene '{scene.name}' is now '{scene.play_count}' and the date the scene was last played is '{scene.date_last_played}'"
     )
     scene.save()
 
     for scene_tag in scene.scene_tags.all():
         scene_tag.play_count += 1
         print(
-            "Play count for scene tag '{}' is now '{}'".format(
-                scene_tag.name, scene_tag.play_count
-            )
+            f"Play count for scene tag '{scene_tag.name}' is now '{scene_tag.play_count}'"
         )
         scene_tag.save()
 
     for actor in scene.actors.all():
         actor.play_count += 1
-        print(
-            "Play count for actor '{}' is now '{}'".format(actor.name, actor.play_count)
-        )
+        print(f"Play count for actor '{actor.name}' is now '{actor.play_count}'")
         actor.save()
 
     for website in scene.websites.all():
         website.play_count += 1
         print(
-            "Play count for site '{}' is now '{}'".format(
-                website.name, website.play_count
-            )
+            f"Play count for site '{website.name}' is now '{website.play_count}'"
         )
         website.save()
 
@@ -1138,9 +1060,9 @@ def play_scene_vlc(scene, random):
         if not pls.scenes.filter(id=scene.id):
             pls.scenes.add(scene)
             pls.save()
-            print("Added scene '{}' to Random Plays playlist.".format(scene.name))
+            print(f"Added scene '{scene.name}' to Random Plays playlist.")
         else:
-            print("Scene '{}' already in playlist Random Plays.".format(scene.name))
+            print(f"Scene '{scene.name}' already in playlist Random Plays.")
 
 
 @api_view(["GET", "POST"])
@@ -1262,8 +1184,10 @@ class AssetAdd(views.APIView):
 
                     current_tumb = os.path.join(
                         const.MEDIA_PATH,
-                        "actor/{}/".format(actor.id),
-                        "profile/profile.jpg",
+                        "actor",
+                        f"{actor.id}",
+                        "profile",
+                        "profile.jpg",
                     )
                     print(current_tumb)
 
@@ -1295,7 +1219,7 @@ class FileUploadView(views.APIView):
 
 def angualr_index(request):
 
-    return render(request, "videos/angular/index.html")
+    return render(request, os.path.join("videos","angular","index.html"))
 
 
 @api_view(["GET"])
@@ -1495,7 +1419,7 @@ def display_video(x):
         #return HttpResponse("No Video")
     sceneid = x.path
     sceneid = sceneid.split('/')[-1]
-    print ("Requesting scene ID " + str(sceneid) + "...\r", end="")
+    print (f"Requesting scene ID {sceneid}...\r", end="")
     scene = Scene.objects.get(pk=sceneid)
     pathname = scene.path_to_file
     size = scene.size
@@ -1506,7 +1430,7 @@ def display_video(x):
     else:
         then = datetime.datetime.now() - timedelta(hours = 12)
     if now > then + timedelta(hours=3):
-        print ("Playback: [" + pathname + "] (" + str(int(size/1024/1024))+" MB)")
+        print (f"Playback: [{pathname}] ({size//1048576} MB)")#1048576 is 1024^2
         scene.play_count+=1
         scene.date_last_played=datetime.datetime.now()
         scene.save()


### PR DESCRIPTION
I used inline format strings where necessary, because:
- Inline format strings are about twice as fast as old-style format strings
- Inline format strings take about 2/5 the time of new-style format strings
- conactenation takes pretty much the same time when less variables are used, but the time rises drastically with variable count.
- also many people find inline format strings a lot more readable than any of the options above, and I'm one of those people.

inline → `f"{v1} {v2}"`
new → `"{} {}".format(v1,v2)`
old → `"%s %s"%(v1,v2)`
concat → `v1 + " " + v2` (assuming v1 and v2 are strings)

Also I fixed some weird path formatting & fixed possible infinite path strings (use `os.path.dirname(odir)` instead of `os.path.join(odir,"..")`)

Also also I replaced some iconcat forloops with .join() because that's faster, more readable, and way less code.