### PR TITLE
Make file-extension whitelisting case-insensitive

### DIFF
--- a/videos/addScenes.py
+++ b/videos/addScenes.py
@@ -42,7 +42,7 @@ def get_files(walk_dir, make_video_sample):
         #     for subdir in subdirs:
         #         print('\t- subdirectory ' + subdir)
 
-        if not root.startswith("$") or root.startswith(".") or subdirs.startswith("$") or subdirs.startswith("."):
+        if not root.startswith("$") or root.startswith("."):
 
             for filename in files:
                 file_path = os.path.join(root, filename)

--- a/videos/addScenes.py
+++ b/videos/addScenes.py
@@ -16,6 +16,7 @@ from videos.models import *
 
 os.environ.setdefault("DJANGO_SETTINGS_MODULE", "YAPO.settings")
 
+# These should be lower-case.
 ACCEPTED_VIDEO_EXTENSIONS = {
     ".mp4",
     ".avi",
@@ -48,7 +49,7 @@ def get_files(walk_dir, make_video_sample):
                 file_path = os.path.join(root, filename)
                 filename_extension = os.path.splitext(file_path)[1]
                 for filename_extension_to_test in ACCEPTED_VIDEO_EXTENSIONS:
-                    if filename_extension_to_test == filename_extension:
+                    if filename_extension_to_test == filename_extension.lower():
                         print(
                             f"Filename is {file_path}\nExtension is {filename_extension}\n"
                         )

--- a/videos/startup.py
+++ b/videos/startup.py
@@ -268,7 +268,7 @@ def startup_sequence():
 
     #aux.populate_actors()
 
-    if "runserver" in sys.argv[1]:
+    if len(sys.argv) > 1 and "runserver" in sys.argv[1]:
         site = Config().yapo_url
         if ":" in site:
             if not ("http://") in site:


### PR DESCRIPTION
Accept files with extensions in capitialised versions of accepted extensions