### PR TITLE
Correct CPU freq detection on constant-speed systems

### DIFF
--- a/videos/aux_functions.py
+++ b/videos/aux_functions.py
@@ -46,10 +46,17 @@ def getMemory ():
     return vmem  # "{:.2}".format(vmem.total/100000000) #shold that be 102400000?
 
 
-def getCPU ():
+def getCPU():
     import psutil
-    cpufreq = round(psutil.cpu_freq().max / 1000, 1)
-    return cpufreq
+    cpuinfo = psutil.cpu_freq()
+    # On some systems, 'max' will be 0.0. In this case, use the current speed.
+    if cpuinfo.max == 0.0:
+        cpufreqMhz = cpuinfo.current
+    else:
+        cpufreqMhz = cpuinfo.max
+
+    cpufreqGhz = round(cpufreqMhz / 1000, 1)
+    return cpufreqGhz
 
 
 def getCPUCount ():


### PR DESCRIPTION
On systems where clockspeed is constant, psutils will return zero for max speed. I'm seeing this on my VMWare ESXi guests. This patch will use the current clockspeed if no max is available.